### PR TITLE
ci: harden workflows and release checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,12 +4,39 @@ on:
   schedule:
     - cron: "0 9 * * 1" # Every Monday 9am UTC
   push:
-    paths: [Cargo.lock]
+    paths:
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+
+permissions:
+  contents: read
 
 jobs:
   audit:
     name: Cargo audit
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  scheduled-audit:
+    name: Scheduled cargo audit
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      issues: write
     steps:
       - uses: actions/checkout@v5
       - uses: rustsec/audit-check@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
+        continue-on-error: true
 
       - name: Format check
         run: cargo fmt --all -- --check
@@ -63,14 +64,17 @@ jobs:
         working-directory: hola-py
 
       - name: Ruff format check
+        if: matrix.python-version == '3.12'
         run: uv run ruff format --check .
         working-directory: hola-py
 
       - name: Ruff lint
+        if: matrix.python-version == '3.12'
         run: uv run ruff check .
         working-directory: hola-py
 
       - name: Type check (ty)
+        if: matrix.python-version == '3.12'
         run: uv run ty check .
         working-directory: hola-py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
@@ -38,8 +41,12 @@ jobs:
 
   # ── Python: build bindings + ruff + ty + pytest ───────
   python:
-    name: Python
+    name: Python (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
     steps:
       - uses: actions/checkout@v5
 
@@ -47,12 +54,12 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - uses: astral-sh/setup-uv@v5
 
       - name: Install dev + benchmark dependencies
-        run: uv sync --dev --group benchmarks
+        run: uv sync --locked --dev --group benchmarks
         working-directory: hola-py
 
       - name: Ruff format check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,16 +6,92 @@ on:
       - "v*"
 
 permissions:
-  contents: write
-  pages: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  validate-release:
+    name: Validate Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate tag and package versions
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${TAG_NAME#v}"
+          if [[ "${TAG_NAME}" != v* || -z "${version}" || "${version}" == "${TAG_NAME}" ]]; then
+            echo "Release tags must be named v<version>; got ${TAG_NAME}" >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          main_sha="$(git rev-parse origin/main)"
+          tag_sha="$(git rev-list -n 1 "${TAG_NAME}")"
+          if [[ "${tag_sha}" != "${main_sha}" ]]; then
+            echo "Release tag ${TAG_NAME} points to ${tag_sha}, but origin/main is ${main_sha}" >&2
+            exit 1
+          fi
+
+          TAG_VERSION="${version}" python <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          version = os.environ["TAG_VERSION"]
+          errors: list[str] = []
+
+          pyproject = tomllib.loads(Path("hola-py/pyproject.toml").read_text())
+          if pyproject["project"]["version"] != version:
+              errors.append(
+                  f"hola-py/pyproject.toml project.version is {pyproject['project']['version']!r}, expected {version!r}"
+              )
+
+          manifests = [
+              Path("opt_engine/Cargo.toml"),
+              Path("hola/Cargo.toml"),
+              Path("hola-py/Cargo.toml"),
+              Path("hola-cli/Cargo.toml"),
+          ]
+          for manifest in manifests:
+              data = tomllib.loads(manifest.read_text())
+              package_version = data["package"]["version"]
+              if package_version != version:
+                  errors.append(f"{manifest} package.version is {package_version!r}, expected {version!r}")
+              for section in ("dependencies", "dev-dependencies"):
+                  for dep_name, dep in data.get(section, {}).items():
+                      if isinstance(dep, dict) and "path" in dep and "version" in dep and dep["version"] != version:
+                          errors.append(
+                              f"{manifest} {section}.{dep_name}.version is {dep['version']!r}, expected {version!r}"
+                          )
+              for table, deps in data.items():
+                  if not table.startswith("dev-dependencies."):
+                      continue
+                  if isinstance(deps, dict) and "path" in deps and "version" in deps and deps["version"] != version:
+                      errors.append(f"{manifest} {table}.version is {deps['version']!r}, expected {version!r}")
+
+          if errors:
+              raise SystemExit("\n".join(errors))
+          PY
+
   # ── Python wheels (abi3 — one per platform) ─────────────
   build-wheels:
     name: Wheel (${{ matrix.os }} ${{ matrix.target }})
+    needs: [validate-release]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -69,6 +145,7 @@ jobs:
   # ── Source distribution ─────────────────────────────────
   build-sdist:
     name: Source distribution
+    needs: [validate-release]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -89,6 +166,7 @@ jobs:
   # ── CLI binaries ────────────────────────────────────────
   build-cli:
     name: CLI (${{ matrix.target }})
+    needs: [validate-release]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -183,6 +261,8 @@ jobs:
     name: GitHub Release
     needs: [build-wheels, build-sdist, build-cli, test-wheels]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
 
@@ -205,23 +285,38 @@ jobs:
     name: Update Package Index
     needs: [release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
 
       - name: Generate PEP 503 simple index
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           mkdir -p index/simple/hola-opt
 
-          # Collect wheel/sdist download URLs from all stable GitHub releases.
+          # Collect wheel/sdist download URLs from stable releases. If no stable
+          # release exists yet, index only the current prerelease so old RC assets
+          # with obsolete package versions do not remain install candidates.
           # gh release view returns browser-downloadable URLs in .assets[].url.
           gh release list --limit 100 --json tagName,isPrerelease \
-            --jq '.[] | select(.isPrerelease == false) | .tagName' | while read -r tag; do
+            --jq '.[] | select(.isPrerelease == false) | .tagName' > /tmp/index_tags.txt
+          if [[ ! -s /tmp/index_tags.txt ]]; then
+            echo "${CURRENT_TAG}" > /tmp/index_tags.txt
+          fi
+
+          while read -r tag; do
             gh release view "$tag" --json assets \
               --jq '[.assets[] | select(.name | test("\\.(whl|tar\\.gz)$")) | .url] | .[]'
-          done | sort -u > /tmp/asset_urls.txt
+          done < /tmp/index_tags.txt | sort -u > /tmp/asset_urls.txt
+
+          if [[ ! -s /tmp/asset_urls.txt ]]; then
+            echo "No wheel or sdist assets found for the package index" >&2
+            exit 1
+          fi
 
           # Build the per-package index page (PEP 503)
           {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
+        continue-on-error: true
 
       - name: Install cross-compilation tools
         if: matrix.target == 'aarch64-unknown-linux-gnu'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1393,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hola"
-version = "0.1.0"
+version = "1.0.1-rc5"
 dependencies = [
  "axum",
  "chrono",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "hola-cli"
-version = "0.1.0"
+version = "1.0.1-rc5"
 dependencies = [
  "clap",
  "hola",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "hola-py"
-version = "0.1.0"
+version = "1.0.1-rc5"
 dependencies = [
  "hola",
  "pyo3",
@@ -1021,7 +1021,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opt_engine"
-version = "0.1.0"
+version = "1.0.1-rc5"
 dependencies = [
  "chrono",
  "nalgebra",

--- a/hola-cli/Cargo.toml
+++ b/hola-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hola-cli"
-version = "0.1.0"
+version = "1.0.1-rc5"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -9,7 +9,7 @@ name = "hola"
 path = "src/main.rs"
 
 [dependencies]
-hola = { path = "../hola", features = ["server"], version = "0.1.0" }
+hola = { path = "../hola", features = ["server"], version = "1.0.1-rc5" }
 clap = { version = "4", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1"

--- a/hola-py/Cargo.toml
+++ b/hola-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hola-py"
-version = "0.1.0"
+version = "1.0.1-rc5"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -9,7 +9,7 @@ name = "hola_opt"
 crate-type = ["cdylib"]
 
 [dependencies]
-hola_engine = { package = "hola", version = "0.1.0", path = "../hola", features = ["server"] }
+hola_engine = { package = "hola", version = "1.0.1-rc5", path = "../hola", features = ["server"] }
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/hola-py/pyproject.toml
+++ b/hola-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "hola-opt"
-version = "0.1.0"
+version = "1.0.1-rc5"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 classifiers = [

--- a/hola-py/uv.lock
+++ b/hola-py/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "hola-opt"
-version = "0.1.0"
+version = "1.0.1rc5"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/hola/Cargo.toml
+++ b/hola/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hola"
-version = "0.1.0"
+version = "1.0.1-rc5"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -9,7 +9,7 @@ default = []
 server = ["axum", "tokio-stream", "tower-http"]
 
 [dependencies]
-opt_engine = { version = "0.1.0", path = "../opt_engine" }
+opt_engine = { version = "1.0.1-rc5", path = "../opt_engine" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
@@ -20,7 +20,7 @@ tokio-stream = { version = "0.1", features = ["sync"], optional = true }
 tower-http = { version = "0.6.8", features = ["cors", "fs"], optional = true }
 
 [dev-dependencies]
-opt_engine = { version = "0.1.0", path = "../opt_engine" }
+opt_engine = { version = "1.0.1-rc5", path = "../opt_engine" }
 serde_yaml = "0.9"
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/opt_engine/Cargo.toml
+++ b/opt_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opt_engine"
-version = "0.1.0"
+version = "1.0.1-rc5"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary
- harden workflow token permissions and lock Python dependency sync in CI
- run Rust security audit on Cargo manifest/lock changes, including PRs
- add release validation for tag/main/version consistency
- make the package index avoid stale prerelease assets when no stable release exists
- add Dependabot maintenance for GitHub Actions
- bump package metadata to 1.0.1-rc5 for the next release candidate

## Validation
- actionlint
- YAML parse
- git diff --check
- cargo fmt --all -- --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --workspace --all-features
- uv lock --check
- uv sync --locked --dev --group benchmarks
- ruff format --check, ruff check, ty check
- release guard dry run
- package index asset collection dry run