### PR TITLE
Prepare v1.0.1-rc8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.1-rc8
+
 - API tokens now protect read endpoints and SSE by default. The explicit
   `--allow-unauthenticated-reads` flag restores the prior open-read behavior
   for trusted deployments.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hola"
-version = "1.0.1-rc7"
+version = "1.0.1-rc8"
 dependencies = [
  "axum",
  "constant_time_eq",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "hola-cli"
-version = "1.0.1-rc7"
+version = "1.0.1-rc8"
 dependencies = [
  "clap",
  "command-group",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "hola-py"
-version = "1.0.1-rc7"
+version = "1.0.1-rc8"
 dependencies = [
  "hola",
  "pyo3",
@@ -1077,7 +1077,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opt_engine"
-version = "1.0.1-rc7"
+version = "1.0.1-rc8"
 dependencies = [
  "chrono",
  "nalgebra",

--- a/hola-cli/Cargo.toml
+++ b/hola-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hola-cli"
-version = "1.0.1-rc7"
+version = "1.0.1-rc8"
 edition = "2024"
 description = "Command-line server and distributed worker for HOLA"
 documentation = "https://github.com/blackrock/HOLA/blob/main/docs/cli-guide.md"
@@ -19,7 +19,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-hola = { path = "../hola", features = ["server"], version = "1.0.1-rc7" }
+hola = { path = "../hola", features = ["server"], version = "1.0.1-rc8" }
 clap = { version = "4", features = ["derive"] }
 # Keep the established module name while using the maintained, API-compatible fork.
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }

--- a/hola-py/Cargo.toml
+++ b/hola-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hola-py"
-version = "1.0.1-rc7"
+version = "1.0.1-rc8"
 edition = "2024"
 description = "Python bindings for the HOLA hyperparameter optimization engine"
 documentation = "https://github.com/blackrock/HOLA/blob/main/docs/python-guide.md"
@@ -18,7 +18,7 @@ name = "hola_opt"
 crate-type = ["cdylib"]
 
 [dependencies]
-hola_engine = { package = "hola", version = "1.0.1-rc7", path = "../hola", features = ["server"] }
+hola_engine = { package = "hola", version = "1.0.1-rc8", path = "../hola", features = ["server"] }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py310"] }
 serde = "1"
 serde_json = "1"

--- a/hola-py/pyproject.toml
+++ b/hola-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "hola-opt"
-version = "1.0.1-rc7"
+version = "1.0.1-rc8"
 description = "Lightweight asynchronous hyperparameter optimization backed by Rust"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/hola-py/uv.lock
+++ b/hola-py/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "hola-opt"
-version = "1.0.1rc7"
+version = "1.0.1rc8"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/hola/Cargo.toml
+++ b/hola/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hola"
-version = "1.0.1-rc7"
+version = "1.0.1-rc8"
 edition = "2024"
 description = "Dynamic optimization engine and optional REST server for HOLA"
 documentation = "https://docs.rs/hola"
@@ -18,7 +18,7 @@ default = []
 server = ["axum/http1", "axum/json", "axum/query", "axum/tokio", "tokio/net", "tokio/signal", "tokio-stream", "tower-http", "tracing"]
 
 [dependencies]
-opt_engine = { version = "1.0.1-rc7", path = "../opt_engine" }
+opt_engine = { version = "1.0.1-rc8", path = "../opt_engine" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Core engine needs async locks and blocking refit tasks; server adds net support.
@@ -32,7 +32,7 @@ tokio-stream = { version = "0.1", default-features = false, features = ["sync"],
 tower-http = { version = "0.6.8", default-features = false, features = ["cors", "fs", "request-id", "timeout", "trace"], optional = true }
 
 [dev-dependencies]
-opt_engine = { version = "1.0.1-rc7", path = "../opt_engine" }
+opt_engine = { version = "1.0.1-rc8", path = "../opt_engine" }
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/opt_engine/Cargo.toml
+++ b/opt_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opt_engine"
-version = "1.0.1-rc7"
+version = "1.0.1-rc8"
 edition = "2024"
 description = "Type-safe optimization primitives and search strategies for HOLA"
 documentation = "https://docs.rs/opt_engine"


### PR DESCRIPTION
## Summary

- bump all four Rust packages and versioned internal path dependencies to
  `1.0.1-rc8`
- set the Python project version to `1.0.1-rc8` and refresh its normalized
  `1.0.1rc8` lock entry
- refresh only the four workspace package versions in `Cargo.lock`
- move the completed `Unreleased` notes under `1.0.1-rc8`, leaving an empty
  `Unreleased` section

## Why

This is the isolated release-preparation change following the squash merge of
the cross-platform hardening work. It does not create or move a tag.

## Validation

- exact release-workflow version validation passed
- `cargo fmt --all -- --check`
- strict workspace Clippy with all targets/features
- 465 non-doc Rust tests and 8 doctests
- Rust 1.87 MSRV workspace check
- warnings-as-errors Rustdoc
- 241 Python tests with 4 intentional skips
- Ruff formatting/lint and ty checks
- Cargo package inspection and bundled-dashboard equality
- Cargo and uv lock refreshes contain no dependency upgrades

## After merge

Wait for CI and all three dependency audits on the exact squash commit, finish
the manual release gates, verify canonical `main` has not moved, and only then
create `v1.0.1-rc8` at that exact commit.
