### PR TITLE
Fix dashboard accessibility at narrow viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@
   the versioned dashboard in editable trees, wheels, and source distributions.
 - The dashboard is dependency-free/offline-capable, renders untrusted data as
   inert text, preserves categorical checkpoint metadata, closes snapshot/SSE
-  races with replay cursors, and uses indexed incremental caches for bounded
+  races with replay cursors, keeps controls reachable at narrow viewports,
+  meets AA text contrast, and uses indexed incremental caches for bounded
   six-figure rendering.
 - CI pins toolchains and actions, tests the supported OS/Python/MSRV surfaces,
   audits dependencies, builds release artifacts for supported platforms, and

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1232,7 +1232,7 @@ function renderConvergence() {
     const sy = value => pad.top + ph - (transformY(value) - yMin) / (yMax - yMin) * ph;
 
     ctx.font = '11px system-ui, sans-serif';
-    ctx.fillStyle = '#7070a0';
+    ctx.fillStyle = '#8c8cbc';
     ctx.strokeStyle = 'rgba(255,255,255,0.06)';
     ctx.lineWidth = 1;
     for (let i = 0; i <= 4; i++) {
@@ -1351,7 +1351,7 @@ function renderPareto() {
     }
 
     // Axis labels
-    ctx.fillStyle = '#7070a0';
+    ctx.fillStyle = '#8c8cbc';
     ctx.font = '11px Inter';
     ctx.textAlign = 'center';
     ctx.fillText(xField, pad.left + pw / 2, h - 5);
@@ -1362,7 +1362,7 @@ function renderPareto() {
     ctx.restore();
 
     // Axis tick labels
-    ctx.fillStyle = '#555';
+    ctx.fillStyle = '#8c8cbc';
     ctx.font = '10px JetBrains Mono, monospace';
     ctx.textAlign = 'center';
     for (let i = 0; i <= 4; i++) {
@@ -1639,7 +1639,7 @@ function renderParallel() {
     ctx.strokeStyle = 'rgba(255,255,255,0.1)';
     ctx.lineWidth = 1;
     ctx.font = '10px Inter';
-    ctx.fillStyle = '#7070a0';
+    ctx.fillStyle = '#8c8cbc';
     ctx.textAlign = 'center';
     for (let i = 0; i < n; i++) {
         const x = pad.left + i * gap;
@@ -1649,7 +1649,7 @@ function renderParallel() {
         ctx.stroke();
         ctx.fillText(names[i], x, h - 8);
         // Min/max labels (show choice labels for categorical)
-        ctx.fillStyle = '#555';
+        ctx.fillStyle = '#8c8cbc';
         if (ranges[i].categorical && ranges[i].choices) {
             const choices = ranges[i].choices;
             ctx.fillText(choices[choices.length - 1], x, pad.top - 6);
@@ -1658,7 +1658,7 @@ function renderParallel() {
             ctx.fillText(fmt(ranges[i].max), x, pad.top - 6);
             ctx.fillText(fmt(ranges[i].min), x, pad.top + ph + 14);
         }
-        ctx.fillStyle = '#7070a0';
+        ctx.fillStyle = '#8c8cbc';
     }
 
     // Resolve a param value to a numeric value for the axis

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -23,7 +23,7 @@ limitations under the License.
   --border-glow: #3a3a5e;
   --text-0: #e8e8f0;
   --text-1: #b0b0c8;
-  --text-2: #7070a0;
+  --text-2: #8c8cbc;
   --accent: #6c5ce7;
   --accent-bright: #a29bfe;
   --accent-dim: #4834d4;
@@ -100,6 +100,11 @@ body {
   letter-spacing: 0.08em;
   color: var(--text-2);
 }
+#objectives-card .card-header > div {
+  flex-wrap: wrap;
+  min-width: 0;
+  max-width: 100%;
+}
 
 /* ==========================================================================
    Status Bar
@@ -150,6 +155,7 @@ body {
 #connect-panel input[type="text"],
 #connect-panel input[type="password"] {
   flex: 1;
+  min-width: 0;
   max-width: 400px;
   padding: 8px 14px;
   background: var(--bg-2);
@@ -229,6 +235,7 @@ button:disabled {
   display: flex;
   gap: 12px;
   align-items: center;
+  flex-wrap: wrap;
   margin-bottom: 8px;
 }
 .axis-selectors label {
@@ -237,7 +244,10 @@ button:disabled {
   display: flex;
   align-items: center;
   gap: 4px;
+  min-width: 0;
+  max-width: 100%;
 }
+.axis-selectors select { min-width: 0; max-width: 100%; }
 select {
   padding: 4px 8px;
   background: var(--bg-2);
@@ -436,7 +446,12 @@ input[type="file"] { display: none; }
   #status-bar { gap: 10px; padding: 10px 12px; }
   #connect-panel { width: 100%; flex-wrap: wrap; padding: 8px 0 0; }
   #connect-panel input[type="text"],
-  #connect-panel input[type="password"] { flex: 1 1 100%; max-width: none; }
+  #connect-panel input[type="password"] {
+    flex: 1 1 100%;
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+  }
   .card { padding: 12px; }
   .card-header { align-items: flex-start; gap: 8px; flex-wrap: wrap; }
   canvas { max-width: 100%; }

--- a/dashboard/tests/dashboard_state.test.mjs
+++ b/dashboard/tests/dashboard_state.test.mjs
@@ -22,6 +22,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const DASHBOARD_DIR = resolve(HERE, '..');
 const APP_JS = resolve(DASHBOARD_DIR, 'app.js');
 const INDEX_HTML = resolve(DASHBOARD_DIR, 'index.html');
+const STYLES_CSS = resolve(DASHBOARD_DIR, 'styles.css');
 
 function buildHtml() {
     const appSrc = readFileSync(APP_JS, 'utf8');
@@ -77,7 +78,9 @@ function createDom(fetchImpl = () => new Promise(() => {})) {
         beginPath() {},
         clearRect() {},
         fill() {},
-        fillText(text, x, y) { canvasCalls.push({ op: 'fillText', text, x, y }); },
+        fillText(text, x, y) {
+            canvasCalls.push({ op: 'fillText', text, x, y, fillStyle: this.fillStyle });
+        },
         lineTo(x, y) { canvasCalls.push({ op: 'lineTo', x, y }); },
         moveTo(x, y) { canvasCalls.push({ op: 'moveTo', x, y }); },
         restore() {},
@@ -257,6 +260,159 @@ test('mixed-space rendering and sorting preserve declared categorical order', ()
     } finally {
         dom.window.close();
     }
+});
+
+test('long Pareto axis names can wrap and shrink on narrow viewports', () => {
+    const { dom, window } = createDom();
+    try {
+        const style = window.document.createElement('style');
+        style.textContent = readFileSync(STYLES_CSS, 'utf8');
+        window.document.head.appendChild(style);
+        window.applyCheckpointData({
+            format: 'hola-dashboard-export',
+            space: [],
+            objectives: [
+                { field: 'validation_cross_entropy_loss', obj_type: 'minimize' },
+                { field: 'inference_latency_milliseconds', obj_type: 'minimize' },
+            ],
+            trials: [{
+                trial_id: 0,
+                metrics: {
+                    validation_cross_entropy_loss: 0.25,
+                    inference_latency_milliseconds: 12,
+                },
+                score_vector: {
+                    validation_cross_entropy_loss: 0.25,
+                    inference_latency_milliseconds: 12,
+                },
+                rank: 0,
+                pareto_front: 0,
+            }],
+        });
+
+        const selectors = window.document.querySelector('.axis-selectors');
+        assert.equal(window.getComputedStyle(selectors).flexWrap, 'wrap');
+        for (const label of selectors.querySelectorAll('label')) {
+            const labelStyle = window.getComputedStyle(label);
+            assert.equal(labelStyle.minWidth, '0');
+            assert.equal(labelStyle.maxWidth, '100%');
+        }
+        for (const select of selectors.querySelectorAll('select')) {
+            const selectStyle = window.getComputedStyle(select);
+            assert.equal(selectStyle.minWidth, '0');
+            assert.equal(selectStyle.maxWidth, '100%');
+        }
+    } finally {
+        dom.window.close();
+    }
+});
+
+test('objective actions can wrap and shrink under zoom', () => {
+    const { dom, window } = createDom();
+    try {
+        const style = window.document.createElement('style');
+        style.textContent = readFileSync(STYLES_CSS, 'utf8');
+        window.document.head.appendChild(style);
+        const actions = window.document.querySelector('#objectives-card .card-header > div');
+        const actionsStyle = window.getComputedStyle(actions);
+        assert.equal(actionsStyle.flexWrap, 'wrap');
+        assert.equal(actionsStyle.minWidth, '0');
+        assert.equal(actionsStyle.maxWidth, '100%');
+        for (const input of window.document.querySelectorAll(
+            '#connect-panel input[type="text"], #connect-panel input[type="password"]',
+        )) {
+            const inputStyle = window.getComputedStyle(input);
+            assert.equal(inputStyle.minWidth, '0');
+        }
+    } finally {
+        dom.window.close();
+    }
+});
+
+test('secondary and canvas text retain WCAG AA contrast with safety margin', () => {
+    const css = readFileSync(STYLES_CSS, 'utf8');
+    const app = readFileSync(APP_JS, 'utf8');
+    const token = name => {
+        const match = css.match(new RegExp(`${name}:\\s*(#[0-9a-f]{6})`, 'i'));
+        assert.ok(match, `missing ${name} color token`);
+        return match[1];
+    };
+    const luminance = hex => {
+        const channels = hex.match(/[0-9a-f]{2}/gi).map(channel => {
+            const value = Number.parseInt(channel, 16) / 255;
+            return value <= 0.04045
+                ? value / 12.92
+                : ((value + 0.055) / 1.055) ** 2.4;
+        });
+        return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+    };
+    const contrast = (foreground, background) => {
+        const values = [luminance(foreground), luminance(background)]
+            .sort((left, right) => right - left);
+        return (values[0] + 0.05) / (values[1] + 0.05);
+    };
+
+    const backgrounds = ['--bg-0', '--bg-1', '--bg-2', '--bg-3'];
+    const assertReadable = (foreground, context) => {
+        for (const background of backgrounds) {
+            const ratio = contrast(foreground, token(background));
+            assert.ok(
+                ratio >= 4.75,
+                `${context} ${foreground} on ${background} is only ${ratio}:1`,
+            );
+        }
+    };
+
+    assertReadable(token('--text-2'), 'secondary text');
+
+    // Canvas text does not inherit CSS variables. Exercise every chart renderer
+    // and capture the effective fillStyle at each real fillText call so dynamic
+    // or refactored color assignments cannot silently evade this regression.
+    const { dom, window, canvasCalls } = createDom();
+    try {
+        for (const canvas of window.document.querySelectorAll('canvas')) {
+            Object.defineProperty(canvas.parentElement, 'clientWidth', {
+                configurable: true,
+                value: 640,
+            });
+        }
+        window.applyCheckpointData({
+            format: 'hola-dashboard-export',
+            space: [
+                { name: 'learning_rate', type: 'real', min: 0.001, max: 0.1 },
+                { name: 'optimizer', type: 'categorical', choices: ['adam', 'sgd'] },
+            ],
+            objectives: [
+                { field: 'loss', obj_type: 'minimize' },
+                { field: 'latency', obj_type: 'minimize' },
+            ],
+            trials: [{
+                trial_id: 0,
+                params: { learning_rate: 0.01, optimizer: 'adam' },
+                metrics: { loss: 0.25, latency: 12 },
+                score_vector: { loss: 0.25, latency: 12 },
+                rank: 0,
+                pareto_front: 0,
+            }],
+        });
+        window.renderConvergence();
+        window.renderPareto();
+        window.renderParallel();
+
+        const textCalls = canvasCalls.filter(call => call.op === 'fillText');
+        assert.ok(textCalls.length > 0, 'expected rendered canvas text');
+        for (const call of textCalls) {
+            assert.match(
+                call.fillStyle,
+                /^#[0-9a-f]{6}$/i,
+                `canvas text ${JSON.stringify(call.text)} must use an auditable hex color`,
+            );
+            assertReadable(call.fillStyle, `canvas text ${JSON.stringify(call.text)}`);
+        }
+    } finally {
+        dom.window.close();
+    }
+    assert.doesNotMatch(app, /#(?:555(?:555)?|7070a0)\b/i);
 });
 
 test('live appends replace scalar best and demote dominated Pareto-front trials', () => {

--- a/hola-py/hola_opt/dashboard/app.js
+++ b/hola-py/hola_opt/dashboard/app.js
@@ -1232,7 +1232,7 @@ function renderConvergence() {
     const sy = value => pad.top + ph - (transformY(value) - yMin) / (yMax - yMin) * ph;
 
     ctx.font = '11px system-ui, sans-serif';
-    ctx.fillStyle = '#7070a0';
+    ctx.fillStyle = '#8c8cbc';
     ctx.strokeStyle = 'rgba(255,255,255,0.06)';
     ctx.lineWidth = 1;
     for (let i = 0; i <= 4; i++) {
@@ -1351,7 +1351,7 @@ function renderPareto() {
     }
 
     // Axis labels
-    ctx.fillStyle = '#7070a0';
+    ctx.fillStyle = '#8c8cbc';
     ctx.font = '11px Inter';
     ctx.textAlign = 'center';
     ctx.fillText(xField, pad.left + pw / 2, h - 5);
@@ -1362,7 +1362,7 @@ function renderPareto() {
     ctx.restore();
 
     // Axis tick labels
-    ctx.fillStyle = '#555';
+    ctx.fillStyle = '#8c8cbc';
     ctx.font = '10px JetBrains Mono, monospace';
     ctx.textAlign = 'center';
     for (let i = 0; i <= 4; i++) {
@@ -1639,7 +1639,7 @@ function renderParallel() {
     ctx.strokeStyle = 'rgba(255,255,255,0.1)';
     ctx.lineWidth = 1;
     ctx.font = '10px Inter';
-    ctx.fillStyle = '#7070a0';
+    ctx.fillStyle = '#8c8cbc';
     ctx.textAlign = 'center';
     for (let i = 0; i < n; i++) {
         const x = pad.left + i * gap;
@@ -1649,7 +1649,7 @@ function renderParallel() {
         ctx.stroke();
         ctx.fillText(names[i], x, h - 8);
         // Min/max labels (show choice labels for categorical)
-        ctx.fillStyle = '#555';
+        ctx.fillStyle = '#8c8cbc';
         if (ranges[i].categorical && ranges[i].choices) {
             const choices = ranges[i].choices;
             ctx.fillText(choices[choices.length - 1], x, pad.top - 6);
@@ -1658,7 +1658,7 @@ function renderParallel() {
             ctx.fillText(fmt(ranges[i].max), x, pad.top - 6);
             ctx.fillText(fmt(ranges[i].min), x, pad.top + ph + 14);
         }
-        ctx.fillStyle = '#7070a0';
+        ctx.fillStyle = '#8c8cbc';
     }
 
     // Resolve a param value to a numeric value for the axis

--- a/hola-py/hola_opt/dashboard/styles.css
+++ b/hola-py/hola_opt/dashboard/styles.css
@@ -23,7 +23,7 @@ limitations under the License.
   --border-glow: #3a3a5e;
   --text-0: #e8e8f0;
   --text-1: #b0b0c8;
-  --text-2: #7070a0;
+  --text-2: #8c8cbc;
   --accent: #6c5ce7;
   --accent-bright: #a29bfe;
   --accent-dim: #4834d4;
@@ -100,6 +100,11 @@ body {
   letter-spacing: 0.08em;
   color: var(--text-2);
 }
+#objectives-card .card-header > div {
+  flex-wrap: wrap;
+  min-width: 0;
+  max-width: 100%;
+}
 
 /* ==========================================================================
    Status Bar
@@ -150,6 +155,7 @@ body {
 #connect-panel input[type="text"],
 #connect-panel input[type="password"] {
   flex: 1;
+  min-width: 0;
   max-width: 400px;
   padding: 8px 14px;
   background: var(--bg-2);
@@ -229,6 +235,7 @@ button:disabled {
   display: flex;
   gap: 12px;
   align-items: center;
+  flex-wrap: wrap;
   margin-bottom: 8px;
 }
 .axis-selectors label {
@@ -237,7 +244,10 @@ button:disabled {
   display: flex;
   align-items: center;
   gap: 4px;
+  min-width: 0;
+  max-width: 100%;
 }
+.axis-selectors select { min-width: 0; max-width: 100%; }
 select {
   padding: 4px 8px;
   background: var(--bg-2);
@@ -436,7 +446,12 @@ input[type="file"] { display: none; }
   #status-bar { gap: 10px; padding: 10px 12px; }
   #connect-panel { width: 100%; flex-wrap: wrap; padding: 8px 0 0; }
   #connect-panel input[type="text"],
-  #connect-panel input[type="password"] { flex: 1 1 100%; max-width: none; }
+  #connect-panel input[type="password"] {
+    flex: 1 1 100%;
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+  }
   .card { padding: 12px; }
   .card-header { align-items: flex-start; gap: 8px; flex-wrap: wrap; }
   canvas { max-width: 100%; }


### PR DESCRIPTION
## Summary

- keep connection inputs, objective actions, and Pareto axis selectors reachable at narrow widths and 200% zoom
- raise secondary and canvas text to WCAG AA contrast with a safety margin
- add deterministic layout contracts and runtime canvas-text contrast coverage
- keep the standalone and Python-bundled dashboard assets byte-identical

## Root cause

Several flex children retained their intrinsic minimum width, so long objective names and zoomed controls could overflow the viewport. Secondary text also used colors below the AA threshold, including two canvas tick-label paths that did not inherit the CSS token.

## Validation

- dashboard npm/jsdom suite: 15 passed, including XSS and 100k-state coverage
- dashboard security pytest: 3 passed
- Chromium 149 real-browser gate: offline load, keyboard sorting, reduced motion, axe, 375 px, and 200% zoom passed; 0 axe violations
- Playwright WebKit 26.5 and Firefox 152 gates: offline load and narrow/zoom layout passed
- long-name fixture: 518 px overflow before, 363/363 document width after
- standalone/bundled asset parity and git diff check passed
- two independent reviews found no remaining blockers

Actual macOS Safari, screen-reader announcement quality, subjective usability, and the previous-release browser heap comparison remain explicit final release-checklist gates; this PR does not claim those human-only checks.
