### PR TITLE
Make transport error test portable

### DIFF
--- a/hola-py/tests/test_exceptions.py
+++ b/hola-py/tests/test_exceptions.py
@@ -11,6 +11,8 @@
 
 """Public exception hierarchy and error-mapping regressions."""
 
+import socket
+
 import pytest
 
 from hola_opt import (
@@ -56,13 +58,18 @@ def test_remote_transport_and_url_errors_are_distinct():
     with pytest.raises(ConfigurationError, match="Invalid server URL"):
         Study.connect("not-a-url")
 
-    remote = Study.connect(
-        "http://127.0.0.1:1",
-        connect_timeout=0.1,
-        request_timeout=0.1,
-    )
-    with pytest.raises(RemoteError, match="HTTP connection failed") as raised:
-        remote.ask()
+    # Hold a kernel-assigned port without listening so connects are refused and
+    # another process cannot claim the port before remote.ask() uses it.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as reserved_socket:
+        reserved_socket.bind(("127.0.0.1", 0))
+        host, port = reserved_socket.getsockname()
+        remote = Study.connect(
+            f"http://{host}:{port}",
+            connect_timeout=0.1,
+            request_timeout=0.1,
+        )
+        with pytest.raises(RemoteError, match="HTTP connection failed") as raised:
+            remote.ask()
     assert isinstance(raised.value, ValueError)
 
 


### PR DESCRIPTION
## Summary

- make the public transport-error regression deterministic across Windows and POSIX runners
- reserve a kernel-selected IPv4 loopback port while deliberately leaving it non-listening
- preserve the exact `RemoteError`, `HTTP connection failed`, and `ValueError` compatibility assertions

## Root cause

The previous test connected to `127.0.0.1:1`. On Windows Server 2025 that address can be filtered long enough to hit the intentional 100 ms request timeout, so the release wheel test observed `HTTP request timed out` instead of the connection-refused mapping it was trying to verify. Holding an ephemeral bound/non-listening socket removes both the firewall-sensitive well-known port and the port-selection race.

## Scope

Test-only. Production code and package metadata are unchanged.

## Validation

- focused exception module: 6 passed
- complete Python suite: 204 passed, 42 skipped
- Ruff format and lint passed
- Python 3.12 and Windows/Python 3.14 type checks passed
- git diff check passed
- independent cross-platform review found no blockers

The final non-publishing release workflow will rerun all five wheel platforms, including Windows/Python 3.14, after this is merged.
