### PR TITLE
Harden release verification and provenance

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,10 +1,12 @@
 name: Security Audit
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 9 * * 1" # Every Monday 9am UTC
   push:
     paths:
+      - ".github/workflows/audit.yml"
       - "**/Cargo.toml"
       - "Cargo.lock"
       - "hola-py/pyproject.toml"
@@ -13,6 +15,7 @@ on:
       - "dashboard/tests/package-lock.json"
   pull_request:
     paths:
+      - ".github/workflows/audit.yml"
       - "**/Cargo.toml"
       - "Cargo.lock"
       - "hola-py/pyproject.toml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,10 @@ jobs:
     needs: [validate-release]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -241,18 +245,23 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: hola-linux-x86_64
+            archive: hola-linux-x86_64.tar.gz
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact: hola-linux-aarch64
+            archive: hola-linux-aarch64.tar.gz
           - os: macos-15-intel
             target: x86_64-apple-darwin
             artifact: hola-macos-x86_64
+            archive: hola-macos-x86_64.tar.gz
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: hola-macos-aarch64
+            archive: hola-macos-aarch64.tar.gz
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: hola-windows-x86_64.exe
+            archive: hola-windows-x86_64.exe.zip
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -287,21 +296,24 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cp target/${{ matrix.target }}/release/hola ${{ matrix.artifact }}
-          tar czf ${{ matrix.artifact }}.tar.gz ${{ matrix.artifact }}
+          tar czf ${{ matrix.archive }} ${{ matrix.artifact }}
 
       - name: Package binary (Windows)
         if: runner.os == 'Windows'
         run: |
           cp target/${{ matrix.target }}/release/hola.exe ${{ matrix.artifact }}
-          Compress-Archive -Path ${{ matrix.artifact }} -DestinationPath ${{ matrix.artifact }}.zip
+          Compress-Archive -Path ${{ matrix.artifact }} -DestinationPath ${{ matrix.archive }}
+
+      - name: Attest CLI archive provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: ${{ matrix.archive }}
 
       - name: Upload CLI artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cli-${{ matrix.artifact }}
-          path: |
-            *.tar.gz
-            *.zip
+          path: ${{ matrix.archive }}
 
   # Download and execute every packaged CLI on its native architecture. This
   # runs during the non-publishing dry run as well as the tagged release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,14 @@
 - The dashboard is dependency-free/offline-capable, renders untrusted data as
   inert text, preserves categorical checkpoint metadata, closes snapshot/SSE
   races with replay cursors, keeps controls reachable at narrow viewports,
-  meets AA text contrast, and uses indexed incremental caches for bounded
-  six-figure rendering.
+  keeps focus through keyboard table-sort cycles, disambiguates overlapping
+  parameter and metric columns, meets AA text contrast, and uses indexed
+  incremental caches for bounded six-figure rendering.
 - CI pins toolchains and actions, tests the supported OS/Python/MSRV surfaces,
-  audits dependencies, builds release artifacts for supported platforms, and
-  verifies package metadata, licenses, docs, and dashboard contracts.
+  audits dependencies on the exact release commit, builds release artifacts
+  for supported platforms, emits GitHub provenance for every workflow-uploaded
+  wheel, source distribution, and CLI archive, and verifies package metadata,
+  licenses, docs, and dashboard contracts.
 
 ## 1.0.1-rc7
 

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -28,7 +28,6 @@ const S = {
     objectives: [],           // [{field, type, target, limit, priority, group}]
     serverObjectives: [],    // snapshot of objectives as fetched from the server
     paramNames: [],
-    paramNameSet: new Set(),
     metricNames: [],
     metricCounts: new Map(),
     metricExtents: new Map(),
@@ -45,6 +44,7 @@ const S = {
     paretoCache: null,
     tableCache: null,
     sortCol: null,
+    sortColumn: null,
     sortAsc: true,
     lastTrialTime: null,
     previewActive: false,    // true when client-side rescalarization is active
@@ -415,7 +415,6 @@ async function fetchCompletedTrial(trialId, serverUrl = S.serverUrl) {
 
 function setParamNames(names) {
     S.paramNames = Array.isArray(names) ? names : [];
-    S.paramNameSet = new Set(S.paramNames);
 }
 
 function scoreGroupWidth(trial) {
@@ -627,6 +626,7 @@ function replaceTrials(trials) {
     S.metricNames = [...S.metricCounts.keys()].sort();
     S.paretoCache = null;
     S.tableCache = null;
+    reconcileTableSort();
     rebuildBestAndConvergence();
 }
 
@@ -682,7 +682,7 @@ function upsertTrial(trial) {
         appendConvergenceTrial(trial);
     }
     if (!changedObjectiveShape) updateParetoCacheForAppend(trial, idx, demoted);
-    if (demoted.length > 0 && S.sortCol === 'rank') S.tableCache = null;
+    if (demoted.length > 0 && S.sortColumn?.key === 'builtin:rank') S.tableCache = null;
     else updateTableCacheForAppend(trial, idx);
     return true;
 }
@@ -1718,25 +1718,69 @@ function fmt(v) {
 // ============================================================================
 // Trial Table
 // ============================================================================
+function getTableColumns() {
+    const columns = [
+        { source: 'builtin', name: 'trial_id' },
+        { source: 'builtin', name: 'rank' },
+        ...S.paramNames.map(name => ({ source: 'param', name })),
+        ...S.metricNames.map(name => ({ source: 'metric', name })),
+    ];
+    const nameCounts = new Map();
+    for (const column of columns) {
+        nameCounts.set(column.name, (nameCounts.get(column.name) || 0) + 1);
+    }
+    const sourceLabels = { builtin: 'trial field', param: 'parameter', metric: 'metric' };
+    const sourcePrefixes = { builtin: 'trial', param: 'param', metric: 'metric' };
+    const usedLabels = new Set();
+    return columns.map(column => {
+        const baseLabel = nameCounts.get(column.name) > 1
+            ? `${sourcePrefixes[column.source]} · ${column.name}`
+            : column.name;
+        let label = baseLabel;
+        for (let suffix = 2; usedLabels.has(label); suffix++) label = `${baseLabel} [${suffix}]`;
+        usedLabels.add(label);
+        return {
+            ...column,
+            key: `${column.source}:${column.name}`,
+            label,
+            accessibleLabel: `${sourceLabels[column.source]} ${column.name}`,
+        };
+    });
+}
+
+function reconcileTableSort() {
+    if (!S.sortColumn) return;
+    const replacement = getTableColumns()
+        .find(column => column.key === S.sortColumn.key);
+    if (replacement) {
+        S.sortCol = replacement.name;
+        S.sortColumn = replacement;
+    } else {
+        S.sortCol = null;
+        S.sortColumn = null;
+        S.sortAsc = true;
+    }
+}
+
 function renderTable() {
     const thead = document.getElementById('trial-thead').querySelector('tr');
     const tbody = document.getElementById('trial-tbody');
 
     // Build columns
-    const cols = ['trial_id', 'rank', ...S.paramNames, ...S.metricNames];
+    const cols = getTableColumns();
 
     clearElement(thead);
-    for (const c of cols) {
+    for (const [columnIndex, c] of cols.entries()) {
         const th = document.createElement('th');
         th.scope = 'col';
-        if (S.sortCol === c) {
+        if (S.sortColumn?.key === c.key) {
             th.className = S.sortAsc ? 'sorted-asc' : 'sorted-desc';
             th.setAttribute('aria-sort', S.sortAsc ? 'ascending' : 'descending');
         }
         const button = document.createElement('button');
         button.type = 'button';
-        button.textContent = c;
-        button.setAttribute('aria-label', `Sort trials by ${c}`);
+        button.textContent = c.label;
+        button.setAttribute('aria-label', `Sort trials by ${c.accessibleLabel}`);
         // Keep native button keyboard semantics without changing the compact
         // table-header appearance.
         button.style.background = 'transparent';
@@ -1749,14 +1793,21 @@ function renderTable() {
         button.style.textAlign = 'inherit';
         button.style.width = '100%';
         button.style.cursor = 'pointer';
-        button.addEventListener('click', () => sortTable(c));
+        button.addEventListener('click', () => {
+            const restoreFocus = document.activeElement === button;
+            sortTable(c);
+            if (restoreFocus) {
+                const replacement = thead.children[columnIndex]?.querySelector('button');
+                replacement?.focus({ preventScroll: true });
+            }
+        });
         th.appendChild(button);
         thead.appendChild(th);
     }
 
     const maxRows = 1000;
     let rows;
-    if (S.sortCol) {
+    if (S.sortColumn) {
         rows = getSortedTableEntries(maxRows).map(entry => entry.trial);
     } else {
         // The unsorted view is newest-first-at-the-bottom and only needs the
@@ -1782,11 +1833,13 @@ function renderTable() {
     }
 }
 
-function getCellValue(trial, col) {
-    if (col === 'trial_id') return trial.trial_id;
-    if (col === 'rank') return trial.rank;
-    if (S.paramNameSet.has(col)) return trial.params?.[col] ?? NaN;
-    return trial.metrics?.[col] ?? NaN;
+function getCellValue(trial, column) {
+    if (!column) return NaN;
+    if (column.source === 'builtin' && column.name === 'trial_id') return trial.trial_id;
+    if (column.source === 'builtin' && column.name === 'rank') return trial.rank;
+    if (column.source === 'param') return trial.params?.[column.name] ?? NaN;
+    if (column.source === 'metric') return trial.metrics?.[column.name] ?? NaN;
+    return NaN;
 }
 
 // Normalize a raw cell value to a sortable form: the string 'inf'/'-inf'
@@ -1841,15 +1894,15 @@ function compareCellValues(a, b, asc, column = null) {
 }
 
 function tableCacheKey() {
-    return `${S.sortCol}\u0000${S.sortAsc ? 'asc' : 'desc'}`;
+    return `${S.sortColumn?.key || ''}\u0000${S.sortAsc ? 'asc' : 'desc'}`;
 }
 
 function compareTableEntries(a, b) {
     const cmp = compareCellValues(
-        getCellValue(a.trial, S.sortCol),
-        getCellValue(b.trial, S.sortCol),
+        getCellValue(a.trial, S.sortColumn),
+        getCellValue(b.trial, S.sortColumn),
         S.sortAsc,
-        S.sortCol,
+        S.sortColumn?.source === 'param' ? S.sortColumn.name : null,
     );
     return cmp || a.index - b.index;
 }
@@ -1931,14 +1984,24 @@ function fmtCell(v) {
     return String(v);
 }
 
-function sortTable(col) {
-    if (S.sortCol !== col) {
-        S.sortCol = col;
+function sortTable(column) {
+    let resolved = column;
+    if (typeof column === 'string') {
+        const columns = getTableColumns();
+        resolved = columns.find(candidate => candidate.key === column)
+            || columns.find(candidate => candidate.name === column);
+    }
+    if (!resolved) return;
+    if (S.sortColumn?.key !== resolved.key) {
+        S.sortCol = resolved.name;
+        S.sortColumn = resolved;
         S.sortAsc = true;
     } else if (S.sortAsc) {
+        S.sortColumn = resolved;
         S.sortAsc = false;
     } else {
         S.sortCol = null;
+        S.sortColumn = null;
         S.sortAsc = true;
     }
     S.tableCache = null;

--- a/dashboard/tests/dashboard_state.test.mjs
+++ b/dashboard/tests/dashboard_state.test.mjs
@@ -237,26 +237,147 @@ test('mixed-space rendering and sorting preserve declared categorical order', ()
         assert.equal(optimizerHeader().querySelector('button')?.type, 'button');
         assert.equal(optimizerHeader().querySelector('button')?.tabIndex, 0);
 
-        optimizerHeader().querySelector('button').click();
+        let optimizerButton = optimizerHeader().querySelector('button');
+        optimizerButton.focus();
+        assert.equal(window.document.activeElement, optimizerButton);
+        optimizerButton.click();
+        optimizerButton = optimizerHeader().querySelector('button');
+        assert.equal(window.document.activeElement, optimizerButton);
         let rows = [...window.document.querySelectorAll('#trial-tbody tr')];
         assert.equal(rows[0].children[optimizerColumn].textContent, 'zeta');
         assert.equal(rows[1].children[optimizerColumn].textContent, 'alpha');
         assert.equal(optimizerHeader().getAttribute('aria-sort'), 'ascending');
         assert.equal(window.document.querySelectorAll('#trial-thead th[aria-sort]').length, 1);
 
-        optimizerHeader().querySelector('button').click();
+        optimizerButton.click();
+        optimizerButton = optimizerHeader().querySelector('button');
+        assert.equal(window.document.activeElement, optimizerButton);
         rows = [...window.document.querySelectorAll('#trial-tbody tr')];
         assert.equal(rows[0].children[optimizerColumn].textContent, 'alpha');
         assert.equal(rows[1].children[optimizerColumn].textContent, 'zeta');
         assert.equal(optimizerHeader().getAttribute('aria-sort'), 'descending');
 
-        optimizerHeader().querySelector('button').click();
+        optimizerButton.click();
+        optimizerButton = optimizerHeader().querySelector('button');
+        assert.equal(window.document.activeElement, optimizerButton);
         rows = [...window.document.querySelectorAll('#trial-tbody tr')];
         assert.equal(window.S.sortCol, null);
         assert.equal(optimizerHeader().getAttribute('aria-sort'), null);
         assert.equal(window.document.querySelectorAll('#trial-thead th[aria-sort]').length, 0);
         assert.equal(rows[0].children[optimizerColumn].textContent, 'alpha');
         assert.equal(rows[1].children[optimizerColumn].textContent, 'zeta');
+    } finally {
+        dom.window.close();
+    }
+});
+
+test('sort focus remains on the exact header when column names overlap', () => {
+    const { dom, window } = createDom();
+    try {
+        window.applyCheckpointData({
+            format: 'hola-dashboard-export',
+            space: [
+                { name: 'overlap', type: 'categorical', choices: ['a', 'b'] },
+                { name: 'param · overlap', type: 'integer', min: 0, max: 10 },
+                { name: 'metric:overlap', type: 'integer', min: 0, max: 10 },
+            ],
+            objectives: [{ field: 'loss', obj_type: 'minimize' }],
+            trials: [
+                {
+                    trial_id: 0,
+                    params: { overlap: 'a', 'param · overlap': 3, 'metric:overlap': 9 },
+                    metrics: { loss: 0.2, overlap: 2 },
+                    score_vector: { loss: 0.2 },
+                },
+                {
+                    trial_id: 1,
+                    params: { overlap: 'b', 'param · overlap': 4, 'metric:overlap': 8 },
+                    metrics: { loss: 0.1, overlap: 1 },
+                    score_vector: { loss: 0.1 },
+                },
+            ],
+        });
+
+        const headerButtons = () => [...window.document.querySelectorAll('#trial-thead button')];
+        const labelsBeforeSort = headerButtons().map(button => button.textContent);
+        const namesBeforeSort = headerButtons().map(button => button.getAttribute('aria-label'));
+        assert.equal(new Set(labelsBeforeSort).size, labelsBeforeSort.length);
+        assert.equal(new Set(namesBeforeSort).size, namesBeforeSort.length);
+        assert.ok(labelsBeforeSort.includes('param · overlap'));
+        assert.ok(labelsBeforeSort.includes('param · overlap [2]'));
+        assert.ok(labelsBeforeSort.includes('metric · overlap'));
+
+        let metricButton = headerButtons()
+            .find(button => button.textContent === 'metric · overlap');
+        assert.equal(metricButton.getAttribute('aria-label'), 'Sort trials by metric overlap');
+        metricButton.focus();
+        metricButton.click();
+        metricButton = headerButtons()
+            .find(button => button.textContent === 'metric · overlap');
+        assert.equal(window.document.activeElement, metricButton);
+        assert.equal(metricButton.closest('th').getAttribute('aria-sort'), 'ascending');
+        assert.equal(window.document.querySelectorAll('#trial-thead th[aria-sort]').length, 1);
+
+        const labels = headerButtons().map(button => button.textContent);
+        const parameterColumn = labels.indexOf('param · overlap');
+        const metricColumn = labels.indexOf('metric · overlap');
+        const rows = [...window.document.querySelectorAll('#trial-tbody tr')];
+        assert.equal(rows[0].children[0].textContent, '1');
+        assert.equal(rows[0].children[parameterColumn].textContent, 'b');
+        assert.equal(rows[0].children[metricColumn].textContent, '1');
+        assert.equal(rows[1].children[0].textContent, '0');
+        assert.equal(rows[1].children[parameterColumn].textContent, 'a');
+        assert.equal(rows[1].children[metricColumn].textContent, '2');
+
+        window.sortTable('metric:overlap');
+        assert.equal(window.S.sortColumn.key, 'metric:overlap');
+        assert.equal(window.S.sortAsc, false);
+        assert.equal(window.document.querySelectorAll('#trial-thead th[aria-sort]').length, 1);
+        const descendingRows = [...window.document.querySelectorAll('#trial-tbody tr')];
+        assert.equal(descendingRows[0].children[0].textContent, '0');
+    } finally {
+        dom.window.close();
+    }
+});
+
+test('replacement checkpoints clear sort state for removed columns', () => {
+    const { dom, window } = createDom();
+    try {
+        window.applyCheckpointData({
+            format: 'hola-dashboard-export',
+            space: [{ name: 'old', type: 'integer', min: 0, max: 1 }],
+            objectives: [{ field: 'loss', obj_type: 'minimize' }],
+            trials: [{
+                trial_id: 0,
+                params: { old: 0 },
+                metrics: { loss: 0 },
+                score_vector: { loss: 0 },
+            }],
+        });
+        window.sortTable('param:old');
+        assert.equal(window.S.sortColumn.key, 'param:old');
+
+        const trials = Array.from({ length: 1001 }, (_, index) => ({
+            trial_id: 10_000 + index,
+            params: { current: index },
+            metrics: { loss: index },
+            score_vector: { loss: index },
+        }));
+        window.applyCheckpointData({
+            format: 'hola-dashboard-export',
+            space: [{ name: 'current', type: 'integer', min: 0, max: 1000 }],
+            objectives: [{ field: 'loss', obj_type: 'minimize' }],
+            trials,
+        });
+
+        assert.equal(window.S.sortCol, null);
+        assert.equal(window.S.sortColumn, null);
+        assert.equal(window.S.sortAsc, true);
+        assert.equal(window.document.querySelectorAll('#trial-thead th[aria-sort]').length, 0);
+        const rows = [...window.document.querySelectorAll('#trial-tbody tr')];
+        assert.equal(rows.length, 1000);
+        assert.equal(rows[0].children[0].textContent, '10001');
+        assert.equal(rows.at(-1).children[0].textContent, '11000');
     } finally {
         dom.window.close();
     }

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,9 +1,9 @@
 # Release Verification Checklist
 
-Run this checklist on the exact release commit after CI and the scheduled
-security workflow are green. Record the commit, date, operator, browser/OS
-versions, and measured timings in the release notes. A failed item blocks the
-release; it is not a waiver.
+Run this checklist on the exact release commit after the CI and Security Audit
+workflow runs for that commit are green. Record both run URLs and SHAs together
+with the commit, date, operator, browser/OS versions, and measured timings in
+the release notes. A failed item blocks the release; it is not a waiver.
 
 ## Hosted compatibility
 
@@ -91,3 +91,12 @@ peak heap and compare it with the previous release.
   `PYTHONPATH`; run the public Python tests and a CLI ask/tell smoke test.
 - Confirm the dashboard files bundled in the wheel exactly match the reviewed
   standalone assets.
+- Verify GitHub build provenance for every wheel, source distribution, and CLI
+  archive, binding it to this workflow and release commit:
+
+  ```bash
+  gh attestation verify PATH_TO_ASSET \
+    --repo blackrock/HOLA \
+    --signer-workflow blackrock/HOLA/.github/workflows/release.yml \
+    --source-digest RELEASE_SHA
+  ```

--- a/hola-py/hola_opt/dashboard/app.js
+++ b/hola-py/hola_opt/dashboard/app.js
@@ -28,7 +28,6 @@ const S = {
     objectives: [],           // [{field, type, target, limit, priority, group}]
     serverObjectives: [],    // snapshot of objectives as fetched from the server
     paramNames: [],
-    paramNameSet: new Set(),
     metricNames: [],
     metricCounts: new Map(),
     metricExtents: new Map(),
@@ -45,6 +44,7 @@ const S = {
     paretoCache: null,
     tableCache: null,
     sortCol: null,
+    sortColumn: null,
     sortAsc: true,
     lastTrialTime: null,
     previewActive: false,    // true when client-side rescalarization is active
@@ -415,7 +415,6 @@ async function fetchCompletedTrial(trialId, serverUrl = S.serverUrl) {
 
 function setParamNames(names) {
     S.paramNames = Array.isArray(names) ? names : [];
-    S.paramNameSet = new Set(S.paramNames);
 }
 
 function scoreGroupWidth(trial) {
@@ -627,6 +626,7 @@ function replaceTrials(trials) {
     S.metricNames = [...S.metricCounts.keys()].sort();
     S.paretoCache = null;
     S.tableCache = null;
+    reconcileTableSort();
     rebuildBestAndConvergence();
 }
 
@@ -682,7 +682,7 @@ function upsertTrial(trial) {
         appendConvergenceTrial(trial);
     }
     if (!changedObjectiveShape) updateParetoCacheForAppend(trial, idx, demoted);
-    if (demoted.length > 0 && S.sortCol === 'rank') S.tableCache = null;
+    if (demoted.length > 0 && S.sortColumn?.key === 'builtin:rank') S.tableCache = null;
     else updateTableCacheForAppend(trial, idx);
     return true;
 }
@@ -1718,25 +1718,69 @@ function fmt(v) {
 // ============================================================================
 // Trial Table
 // ============================================================================
+function getTableColumns() {
+    const columns = [
+        { source: 'builtin', name: 'trial_id' },
+        { source: 'builtin', name: 'rank' },
+        ...S.paramNames.map(name => ({ source: 'param', name })),
+        ...S.metricNames.map(name => ({ source: 'metric', name })),
+    ];
+    const nameCounts = new Map();
+    for (const column of columns) {
+        nameCounts.set(column.name, (nameCounts.get(column.name) || 0) + 1);
+    }
+    const sourceLabels = { builtin: 'trial field', param: 'parameter', metric: 'metric' };
+    const sourcePrefixes = { builtin: 'trial', param: 'param', metric: 'metric' };
+    const usedLabels = new Set();
+    return columns.map(column => {
+        const baseLabel = nameCounts.get(column.name) > 1
+            ? `${sourcePrefixes[column.source]} · ${column.name}`
+            : column.name;
+        let label = baseLabel;
+        for (let suffix = 2; usedLabels.has(label); suffix++) label = `${baseLabel} [${suffix}]`;
+        usedLabels.add(label);
+        return {
+            ...column,
+            key: `${column.source}:${column.name}`,
+            label,
+            accessibleLabel: `${sourceLabels[column.source]} ${column.name}`,
+        };
+    });
+}
+
+function reconcileTableSort() {
+    if (!S.sortColumn) return;
+    const replacement = getTableColumns()
+        .find(column => column.key === S.sortColumn.key);
+    if (replacement) {
+        S.sortCol = replacement.name;
+        S.sortColumn = replacement;
+    } else {
+        S.sortCol = null;
+        S.sortColumn = null;
+        S.sortAsc = true;
+    }
+}
+
 function renderTable() {
     const thead = document.getElementById('trial-thead').querySelector('tr');
     const tbody = document.getElementById('trial-tbody');
 
     // Build columns
-    const cols = ['trial_id', 'rank', ...S.paramNames, ...S.metricNames];
+    const cols = getTableColumns();
 
     clearElement(thead);
-    for (const c of cols) {
+    for (const [columnIndex, c] of cols.entries()) {
         const th = document.createElement('th');
         th.scope = 'col';
-        if (S.sortCol === c) {
+        if (S.sortColumn?.key === c.key) {
             th.className = S.sortAsc ? 'sorted-asc' : 'sorted-desc';
             th.setAttribute('aria-sort', S.sortAsc ? 'ascending' : 'descending');
         }
         const button = document.createElement('button');
         button.type = 'button';
-        button.textContent = c;
-        button.setAttribute('aria-label', `Sort trials by ${c}`);
+        button.textContent = c.label;
+        button.setAttribute('aria-label', `Sort trials by ${c.accessibleLabel}`);
         // Keep native button keyboard semantics without changing the compact
         // table-header appearance.
         button.style.background = 'transparent';
@@ -1749,14 +1793,21 @@ function renderTable() {
         button.style.textAlign = 'inherit';
         button.style.width = '100%';
         button.style.cursor = 'pointer';
-        button.addEventListener('click', () => sortTable(c));
+        button.addEventListener('click', () => {
+            const restoreFocus = document.activeElement === button;
+            sortTable(c);
+            if (restoreFocus) {
+                const replacement = thead.children[columnIndex]?.querySelector('button');
+                replacement?.focus({ preventScroll: true });
+            }
+        });
         th.appendChild(button);
         thead.appendChild(th);
     }
 
     const maxRows = 1000;
     let rows;
-    if (S.sortCol) {
+    if (S.sortColumn) {
         rows = getSortedTableEntries(maxRows).map(entry => entry.trial);
     } else {
         // The unsorted view is newest-first-at-the-bottom and only needs the
@@ -1782,11 +1833,13 @@ function renderTable() {
     }
 }
 
-function getCellValue(trial, col) {
-    if (col === 'trial_id') return trial.trial_id;
-    if (col === 'rank') return trial.rank;
-    if (S.paramNameSet.has(col)) return trial.params?.[col] ?? NaN;
-    return trial.metrics?.[col] ?? NaN;
+function getCellValue(trial, column) {
+    if (!column) return NaN;
+    if (column.source === 'builtin' && column.name === 'trial_id') return trial.trial_id;
+    if (column.source === 'builtin' && column.name === 'rank') return trial.rank;
+    if (column.source === 'param') return trial.params?.[column.name] ?? NaN;
+    if (column.source === 'metric') return trial.metrics?.[column.name] ?? NaN;
+    return NaN;
 }
 
 // Normalize a raw cell value to a sortable form: the string 'inf'/'-inf'
@@ -1841,15 +1894,15 @@ function compareCellValues(a, b, asc, column = null) {
 }
 
 function tableCacheKey() {
-    return `${S.sortCol}\u0000${S.sortAsc ? 'asc' : 'desc'}`;
+    return `${S.sortColumn?.key || ''}\u0000${S.sortAsc ? 'asc' : 'desc'}`;
 }
 
 function compareTableEntries(a, b) {
     const cmp = compareCellValues(
-        getCellValue(a.trial, S.sortCol),
-        getCellValue(b.trial, S.sortCol),
+        getCellValue(a.trial, S.sortColumn),
+        getCellValue(b.trial, S.sortColumn),
         S.sortAsc,
-        S.sortCol,
+        S.sortColumn?.source === 'param' ? S.sortColumn.name : null,
     );
     return cmp || a.index - b.index;
 }
@@ -1931,14 +1984,24 @@ function fmtCell(v) {
     return String(v);
 }
 
-function sortTable(col) {
-    if (S.sortCol !== col) {
-        S.sortCol = col;
+function sortTable(column) {
+    let resolved = column;
+    if (typeof column === 'string') {
+        const columns = getTableColumns();
+        resolved = columns.find(candidate => candidate.key === column)
+            || columns.find(candidate => candidate.name === column);
+    }
+    if (!resolved) return;
+    if (S.sortColumn?.key !== resolved.key) {
+        S.sortCol = resolved.name;
+        S.sortColumn = resolved;
         S.sortAsc = true;
     } else if (S.sortAsc) {
+        S.sortColumn = resolved;
         S.sortAsc = false;
     } else {
         S.sortCol = null;
+        S.sortColumn = null;
         S.sortAsc = true;
     }
     S.tableCache = null;

--- a/hola-py/tests/test_exceptions.py
+++ b/hola-py/tests/test_exceptions.py
@@ -58,19 +58,32 @@ def test_remote_transport_and_url_errors_are_distinct():
     with pytest.raises(ConfigurationError, match="Invalid server URL"):
         Study.connect("not-a-url")
 
-    # Hold a kernel-assigned port without listening so connects are refused and
-    # another process cannot claim the port before remote.ask() uses it.
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as reserved_socket:
-        reserved_socket.bind(("127.0.0.1", 0))
-        host, port = reserved_socket.getsockname()
+    # Select a kernel-assigned loopback port, then close it before connecting.
+    # Keeping a bound socket open without listening can blackhole the SYN until
+    # timeout on macOS and Windows instead of producing a connection refusal.
+    raised = None
+    unexpected_errors = []
+    for _ in range(3):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as reserved_socket:
+            reserved_socket.bind(("127.0.0.1", 0))
+            host, port = reserved_socket.getsockname()
         remote = Study.connect(
             f"http://{host}:{port}",
-            connect_timeout=0.1,
-            request_timeout=0.1,
+            connect_timeout=1.0,
+            request_timeout=1.0,
         )
-        with pytest.raises(RemoteError, match="HTTP connection failed") as raised:
+        try:
             remote.ask()
-    assert isinstance(raised.value, ValueError)
+        except RemoteError as error:
+            if "HTTP connection failed" in str(error):
+                raised = error
+                break
+            unexpected_errors.append(str(error))
+        else:
+            unexpected_errors.append("request unexpectedly succeeded")
+
+    assert raised is not None, f"no connection-refused error after 3 attempts: {unexpected_errors}"
+    assert isinstance(raised, ValueError)
 
 
 def test_invalid_objective_result_raises_objective_error():


### PR DESCRIPTION
## Summary

- close the kernel-selected loopback socket before testing connection refusal, with bounded retries for the unavoidable selection/use race
- make the Security Audit workflow manually dispatchable and self-triggering so the exact frozen release commit is audited
- attest each exact CLI archive with the same pinned GitHub provenance action already used for wheels and the source distribution
- bind release-checklist attestation verification to both the release workflow and exact source SHA
- retain keyboard focus when table-sort headers are rebuilt, source-disambiguate overlapping columns, and clear stale sorts across schema replacement

## Root cause

The exact-main dry run built every artifact and passed both Linux wheel jobs plus all five native CLI archive jobs, but macOS Intel, macOS arm64, and Windows wheel tests timed out in `test_remote_transport_and_url_errors_are_distinct`. A bound-but-non-listening socket is refused immediately on Linux but can blackhole the SYN on macOS and Windows. Closing the selected socket before connecting exercises the intended `reqwest::Error::is_connect()` path across platforms.

The same pre-tag review also found that the checklist required exact-commit audit evidence without a manual audit trigger, and that five public native CLI archives lacked the provenance already emitted for Python artifacts.

Real-browser accessibility verification then found that sorting rebuilt the table header and dropped keyboard focus to the document body after the first activation. The replacement header button now receives focus only when the button it replaced owned focus. Adversarial follow-up testing also found that valid parameter/metric name collisions shared values and sort state, and that a removed column could leave an invisible sort active after schema replacement; table columns now carry exact source-qualified identities and reconcile against each replacement schema.

## Validation

- official actionlint 1.7.10: both modified workflows pass
- Ruff format and lint: pass
- dashboard XSS/state suite: XSS pass and 17/17 state tests, including adversarial names and a 1,001-row schema-transition regression
- Chromium 149 real keyboard gate: Enter three times without refocusing cycles ascending → descending → unsorted and retains focus throughout; overlapping parameter/metric columns remain distinct with one exact `aria-sort`
- Chromium 149 100k-trial benchmark (3 fresh offline runs): 256.6 ms median initial render, 132.4 ms slowest control, 118.4 ms 2k update burst; all budgets and no-2x regression gate pass
- canonical and bundled dashboard assets: byte-identical
- focused exception module: 6 passed
- complete Python suite: 242 passed, 4 skipped
- revised transport regression: 1,000/1,000 passes; raw closed-port probe: 10,000/10,000 immediate refusals locally
- exact workflow/source-bound `gh attestation verify` command successfully verified the current dry-run sdist
- `git diff --check`: pass
- independent workflow/test review found no release-blocking implementation issue

## Required after merge

- wait for the automatic Security Audit on the squash commit
- rerun the full non-publishing Release workflow on the new exact `main`
- verify all 11 downloaded artifacts and all provenance attestations before tagging

No tag or public release exists, and the dry-run release/index jobs remained skipped.
