### PR TITLE
Align GMM refits with Pareto and Gauss-Sobol semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           cargo test --locked -p opt_engine --test integration leaderboard_scalability -- --ignored --nocapture
           cargo test --locked -p opt_engine gmm_hot_path_throughput_probe -- --ignored --nocapture
           cargo test --locked -p hola bounded_refit_workset_scaling_probe -- --ignored --nocapture
+          cargo test --locked -p hola multiobjective_refit_selection_scaling_probe -- --ignored --nocapture
+          cargo test --locked -p hola deferred_multiobjective_batch_scaling_probe -- --ignored --nocapture
           cargo test --locked -p hola tell_hot_path_scaling_probe -- --ignored --nocapture
 
       - name: Documentation (warnings are errors)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Multi-group GMM refits now select elites by Pareto rank and crowding
+  distance, and grouped objectives apply priority weights only within their
+  explicit group.
+- GMM exploitation now uses seeded Owen-scrambled Gauss--Sobol' samples.
+  Configurable sample and candidate limits bound refit work while preserving
+  deterministic coverage of long retained histories, and batched completions
+  can defer repeated multi-objective ranking until the batch is committed.
+
 ## 1.0.1-rc8
 
 - API tokens now protect read endpoints and SSE by default. The explicit

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -144,9 +144,9 @@ following fields.
 |-------|----------|-------------|
 | `field` | yes | The metrics field name to optimize |
 | `type` | yes | `"minimize"` or `"maximize"` |
-| `priority` | no | Relative weight (default: 1.0) |
 | `target` | no | The "satisfactory" value (for TLP) |
-| `limit` | no | The "unacceptable" value (for TLP) |
+| `limit` | no | The worst acceptable boundary (for TLP) |
+| `priority` | no | TLP score at the limit (when configured) and relative weight (default: 1.0) |
 | `group` | no | Priority group name. Objectives in the same group are summed; distinct groups form Pareto axes. Omit for single-group (scalar) studies. |
 
 ```yaml
@@ -175,6 +175,8 @@ strategy:
   seed: 42                 # optional seed for reproducible runs
   exploration_budget: 50   # number of Sobol asks before switching to GMM
   elite_fraction: 0.25     # fraction of top trials used for GMM fitting (default: 0.25)
+  max_refit_samples: 4096  # maximum elite samples passed to one GMM fit
+  max_refit_candidates: 16384  # maximum trials ranked to choose elites
 ```
 
 | Field | Default | Description |
@@ -184,6 +186,12 @@ strategy:
 | `seed` | none | Seed for reproducible runs. When omitted, HOLA draws one seed once and records it in full checkpoints. |
 | `exploration_budget` | none | Number of issued Sobol exploration suggestions before switching to GMM exploitation. Pending asks count against this budget. When omitted, we use a formula based on `total_budget`. |
 | `elite_fraction` | `0.25` | Fraction of top trials used for GMM refitting. Must be in (0.0, 1.0]. |
+| `max_refit_samples` | `4096` | Maximum elite samples passed to one GMM fit. Must be at least 1. |
+| `max_refit_candidates` | `16384` | Maximum retained trials ranked to choose elites. Must be at least `max_refit_samples`; longer histories use deterministic stratified coverage of the full retained history. |
+
+GMM exploitation uses seeded Owen-scrambled Gauss–Sobol' points. One Sobol'
+coordinate selects the mixture component, and inverse-normal coordinates sample
+within that component.
 
 ### Checkpoint Configuration
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -53,9 +53,9 @@ evaluate (your code)
 
 tell()
   ├─ Engine validates metrics against the objective schema
-  ├─ Engine computes per-group costs (plus a scalar fitting proxy)
+  ├─ Engine computes priority-weighted costs within explicit groups
   ├─ Leaderboard stores the trial (params, score_vector, metrics, timestamp)
-  └─ Strategy updates its model from the scalar fitting proxy
+  └─ Strategy refits to scalar-ranked or Pareto/NSGA-II-ranked elites
 ```
 
 ## The Unit Hypercube
@@ -107,6 +107,8 @@ The default strategy is the
 We fit a GMM to the **top quantile** of completed trials, then
 sample new candidates from the fitted model. This concentrates
 samples in regions where good results have been observed.
+For multiple objective groups, the elite order uses non-domination
+rank followed by descending crowding distance.
 
 The lifecycle follows three phases.
 
@@ -116,9 +118,24 @@ The lifecycle follows three phases.
 3. **Exploit.** New samples are drawn from the updated GMM,
    focusing on promising regions.
 
+GMM exploitation uses seeded Owen-scrambled Gauss–Sobol' points.
+One Sobol' coordinate selects the mixture component, and inverse-normal
+coordinates sample within that component.
+
 The exploration budget counts issued suggestions from `ask`,
 including suggestions that are still pending. GMM refits are based
 on completed trials in the leaderboard.
+
+Two implementation limits keep refitting bounded on unusually long studies.
+At most `max_refit_samples` elite points enter one fit (default 4096), and at
+most `max_refit_candidates` retained trials are ranked to choose them (default
+16384). Histories within the candidate limit are ranked globally. Longer
+histories use deterministic chronological strata spanning the full retained
+history, rather than a newest-only window. These are implementation safeguards;
+they do not change the abstract definition of the elite set. Scalar selection
+is linear in the candidate count. General multi-group non-dominated sorting is
+quadratic in the worst case, so long-running studies with many groups may use a
+smaller `max_refit_candidates` value.
 
 This strategy works well for larger budgets (50+ trials) where you
 want to transition from exploration to exploitation. The more
@@ -149,8 +166,8 @@ space matters.
 We convert each metric field into a directed, priority-weighted contribution.
 Contributions in the same priority group are summed. A study with one group
 uses that scalar group cost for ranking; multiple groups retain a cost vector
-and use Pareto/NSGA-II ranking. Strategies may use a summed proxy internally
-for fitting, but the public multi-group leaderboard remains Pareto-ranked.
+and use Pareto/NSGA-II ranking. GMM refits use that same ordering to select
+multi-group elites.
 
 ### Single Field
 
@@ -177,9 +194,12 @@ scalarization. We assign three parameters to each objective field.
 
 - **Target ($t$).** The "satisfactory" value. At or better than
   target, the contribution is 0.
-- **Limit ($l$).** The "unacceptable" value. At or beyond limit,
-  the contribution is infinity (infeasible).
-- **Priority ($p$).** Relative weight in the scalarized sum.
+- **Limit ($l$).** The worst acceptable boundary. At the limit, the
+  contribution is $p$; crossing beyond it makes the trial infeasible and the
+  contribution infinite.
+- **Priority ($p$).** The contribution's score at the limit and its relative
+  weight within a group. The slope between target and limit is
+  $p/(l-t)$; priority is not itself the slope unless $l-t=1$.
 
 Between target and limit, we interpolate linearly
 

--- a/docs/python-guide.md
+++ b/docs/python-guide.md
@@ -29,7 +29,7 @@ The Python API exposes these classes:
 | `Categorical` | Choice from a list of string labels |
 | `Minimize` | Minimize an objective field |
 | `Maximize` | Maximize an objective field |
-| `Gmm` | GMM strategy configuration (refit_interval, elite_fraction, exploration_budget) |
+| `Gmm` | GMM strategy configuration (refit cadence, elite fraction, exploration, and work limits) |
 | `Sobol` | Sobol strategy configuration |
 | `Random` | Random strategy configuration |
 
@@ -199,11 +199,14 @@ objectives=[
 
 - **target.** The "good enough" value. Trials at or better than
   target score 0 for this objective.
-- **limit.** The "unacceptable" value. Trials at or beyond limit
-  score infinity (effectively infeasible).
-- **priority.** Per-objective weight/slope ($P_i$) in the TLP
-  formula:
-  $\varphi_i = P_i \times (\text{value} - \text{target}) / (\text{limit} - \text{target})$.
+- **limit.** The worst acceptable boundary. At the limit, an objective scores
+  `priority`; crossing beyond it makes the trial infeasible and scores infinity.
+- **priority.** The objective's score at the limit and its relative weight
+  within a group ($P_i$). The linear segment's slope is
+  $P_i / (\text{limit} - \text{target})$; `priority` is not itself a slope.
+
+The TLP formula is
+$\varphi_i = P_i \times (\text{value} - \text{target}) / (\text{limit} - \text{target})$.
 
 Between target and limit, the score is interpolated linearly and
 scaled by `priority`. See
@@ -456,9 +459,14 @@ Study(strategy=Gmm(refit_interval=10, elite_fraction=0.1), ...)
 Gaussian Mixture Model strategy. Uses Sobol exploration followed
 by GMM exploitation. Refits a GMM to the top `elite_fraction`
 (default 25%) of trials every `refit_interval` (default 20)
-completed trials. The exploration budget counts issued `ask`
+completed trials. With multiple objective groups, elites are ordered
+by non-domination rank and then descending crowding distance. The
+exploration budget counts issued `ask`
 suggestions, including pending trials. Uses the
 [HOLA algorithm](concepts.md#gmm-strategy).
+GMM exploitation uses seeded Owen-scrambled Gauss–Sobol' points: one
+Sobol' coordinate selects the component, and inverse-normal coordinates
+sample within it.
 
 - Best for larger budgets (50+ trials) where exploration can
   transition to exploitation
@@ -479,6 +487,8 @@ Study(strategy=Gmm(refit_interval=10, elite_fraction=0.1), ...)
 | `refit_interval` | `int` or `None` | 20 | How often the GMM is refit, in completed trials |
 | `elite_fraction` | `float` or `None` | 0.25 | Fraction of top trials used for refitting. Must be in (0, 1]. |
 | `exploration_budget` | `int` or `None` | auto | Number of issued Sobol exploration suggestions before GMM exploitation begins. Pending asks count against this budget. When omitted, computed automatically from the number of dimensions. |
+| `max_refit_samples` | `int` or `None` | 4096 | Maximum elite samples used by one GMM fit. Must be at least 1. |
+| `max_refit_candidates` | `int` or `None` | 16384 | Maximum retained trials ranked during elite selection. Must be at least `max_refit_samples`; longer histories use deterministic stratified coverage. |
 
 ### Sobol
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -543,9 +543,9 @@ Each objective in the array has the following fields.
 |-------|------|----------|-------------|
 | `field` | string | yes | Metrics field name |
 | `obj_type` | string | yes | `"minimize"` or `"maximize"` |
-| `priority` | float | no | Relative weight (default: 1.0) |
 | `target` | float | no | TLP target value |
 | `limit` | float | no | TLP limit value |
+| `priority` | float | no | TLP score at the limit (when configured) and relative weight (default: 1.0) |
 
 **Response (200)**
 

--- a/hola-cli/examples/example_study.yaml
+++ b/hola-cli/examples/example_study.yaml
@@ -38,6 +38,8 @@ objectives:
 strategy:
   type: gmm               # "gmm" (default), "sobol", or "random"
   refit_interval: 20
+  max_refit_samples: 4096
+  max_refit_candidates: 16384
 
 # Optional: automatic checkpointing
 # checkpoint:

--- a/hola-py/examples/basic_optimization.py
+++ b/hola-py/examples/basic_optimization.py
@@ -15,10 +15,14 @@ Demonstrates the core HOLA workflow with TLP scoring:
   1. Minimizing 1D Forrester function using study.run()
   2. Minimizing 2D Branin function using ask/tell loop with Sobol
 
-TLP (Target-Limit-Priority) scoring normalizes each objective to [0, 1]:
+With the default priority of 1, TLP (Target-Limit-Priority) scoring maps:
   - At or below target: score = 0 (satisfied)
   - Between target and limit: score in (0, 1) (acceptable)
+  - At the limit: score = 1
   - Beyond limit: score = inf (infeasible)
+
+In general, priority P is the score at the limit and relative weight; the
+linear segment's slope is P / (limit - target).
 """
 
 from benchmarks.functions.single_objective import branin, forrester

--- a/hola-py/examples/multi_objective.py
+++ b/hola-py/examples/multi_objective.py
@@ -16,9 +16,9 @@ using TLP scoring. Each objective is assigned to a separate group via
 the `group` parameter, so HOLA computes a Pareto front over the two
 TLP-normalized group costs rather than raw values.
 
-The `priority` parameter is the per-objective weight (slope P_i) in
-the TLP formula; `group` controls which objectives are combined into
-the same Pareto axis.
+The `priority` parameter is the per-objective score at the limit and relative
+weight P_i; the linear segment's slope is P_i / (limit - target). `group`
+controls which objectives are combined into the same Pareto axis.
 """
 
 from hola_opt import Integer, Minimize, Real, Space, Study

--- a/hola-py/hola_opt/__init__.pyi
+++ b/hola-py/hola_opt/__init__.pyi
@@ -74,9 +74,10 @@ class Minimize:
         field: Name of the metric to minimize (must appear in the dict returned
             by the objective function).
         target: "Good enough" value -- at or below this, the TLP score is 0.
-        limit: "Unacceptable" value -- beyond this, the trial is infeasible
+        limit: Worst acceptable value -- beyond this, the trial is infeasible
             (score = inf).
-        priority: Per-objective weight/slope in the TLP formula. Default 1.0.
+        priority: Score at the limit and relative weight P. The linear segment's
+            slope is P / (limit - target). Default 1.0.
         group: Priority-group label. Objectives sharing the same group are summed
             into one component of the group-cost vector for Pareto ranking. When
             omitted, defaults to the field name (one group per objective).
@@ -103,9 +104,10 @@ class Maximize:
         field: Name of the metric to maximize (must appear in the dict returned
             by the objective function).
         target: "Good enough" value -- at or above this, the TLP score is 0.
-        limit: "Unacceptable" value -- below this, the trial is infeasible
+        limit: Worst acceptable value -- below this, the trial is infeasible
             (score = inf).
-        priority: Per-objective weight/slope in the TLP formula. Default 1.0.
+        priority: Score at the limit and relative weight P. The linear segment's
+            slope is P / (limit - target). Default 1.0.
         group: Priority-group label. See ``Minimize`` for details.
     """
 
@@ -137,20 +139,28 @@ class Gmm:
         exploration_budget: Number of Sobol exploration trials before GMM
             exploitation begins. When omitted, computed automatically from
             the number of dimensions.
+        max_refit_samples: Maximum elite samples used by one GMM fit
+            (default: 4096).
+        max_refit_candidates: Maximum retained trials ranked during elite
+            selection (default: 16384). Longer histories use deterministic
+            stratified coverage.
 
     Raises:
-        ConfigurationError: If ``elite_fraction`` is non-finite or outside the range
-            ``(0.0, 1.0]``, or if ``refit_interval`` is ``0``.
+        ConfigurationError: If a fraction, interval, or refit limit is invalid.
     """
 
     refit_interval: int | None
     elite_fraction: float | None
     exploration_budget: int | None
+    max_refit_samples: int | None
+    max_refit_candidates: int | None
     def __init__(
         self,
         refit_interval: int | None = None,
         elite_fraction: float | None = None,
         exploration_budget: int | None = None,
+        max_refit_samples: int | None = None,
+        max_refit_candidates: int | None = None,
     ) -> None: ...
 
 class Sobol:

--- a/hola-py/src/lib.rs
+++ b/hola-py/src/lib.rs
@@ -12,7 +12,8 @@
 //! Python bindings for the HOLA optimization engine via PyO3.
 
 use hola_engine::hola_engine::{
-    HolaEngine, ObjectiveConfig, ParamConfig, StrategyConfig, StudyConfig,
+    DEFAULT_MAX_REFIT_CANDIDATES, DEFAULT_MAX_REFIT_SAMPLES, HolaEngine, ObjectiveConfig,
+    ParamConfig, StrategyConfig, StudyConfig,
 };
 use pyo3::create_exception;
 use pyo3::exceptions::{PyRuntimeWarning, PyValueError};
@@ -150,9 +151,9 @@ impl Categorical {
 ///     field: Name of the metric to minimize (must appear in the dict returned
 ///         by the objective function).
 ///     target: "Good enough" value; at or below this, the TLP score is 0.
-///     limit: "Unacceptable" value; beyond this, the trial is infeasible (score = inf).
-///     priority: Per-objective weight/slope P_i in the TLP formula:
-///         φ_i = P_i × (value − target) / (limit − target). Default 1.0.
+///     limit: Worst acceptable value; beyond this, the trial is infeasible (score = inf).
+///     priority: The score at the limit and relative weight P_i. The linear
+///         segment's slope is P_i / (limit − target). Default 1.0.
 ///     group: Priority-group label. Objectives sharing the same group are summed
 ///         into one component of the group-cost vector for Pareto ranking. When
 ///         omitted, defaults to the field name (one group per objective).
@@ -198,8 +199,9 @@ impl Minimize {
 ///     field: Name of the metric to maximize (must appear in the dict returned
 ///         by the objective function).
 ///     target: "Good enough" value; at or above this, the TLP score is 0.
-///     limit: "Unacceptable" value; below this, the trial is infeasible (score = inf).
-///     priority: Per-objective weight/slope P_i in the TLP formula. Default 1.0.
+///     limit: Worst acceptable value; below this, the trial is infeasible (score = inf).
+///     priority: The score at the limit and relative weight P_i. The linear
+///         segment's slope is P_i / (limit − target). Default 1.0.
 ///     group: Priority-group label. See Minimize for details.
 #[pyclass(from_py_object)]
 #[derive(Clone)]
@@ -252,6 +254,9 @@ impl Maximize {
 ///         Must be between 0.0 and 1.0.
 ///     exploration_budget: Number of Sobol exploration trials before GMM exploitation
 ///         begins. When omitted, computed automatically from the number of dimensions.
+///     max_refit_samples: Maximum elite samples used by one GMM fit (default: 4096).
+///     max_refit_candidates: Maximum retained trials ranked during elite selection
+///         (default: 16384). Longer histories use deterministic stratified coverage.
 #[pyclass(from_py_object)]
 #[derive(Clone)]
 struct Gmm {
@@ -261,16 +266,22 @@ struct Gmm {
     elite_fraction: Option<f64>,
     #[pyo3(get)]
     exploration_budget: Option<usize>,
+    #[pyo3(get)]
+    max_refit_samples: Option<usize>,
+    #[pyo3(get)]
+    max_refit_candidates: Option<usize>,
 }
 
 #[pymethods]
 impl Gmm {
     #[new]
-    #[pyo3(signature = (refit_interval=None, elite_fraction=None, exploration_budget=None))]
+    #[pyo3(signature = (refit_interval=None, elite_fraction=None, exploration_budget=None, max_refit_samples=None, max_refit_candidates=None))]
     fn new(
         refit_interval: Option<usize>,
         elite_fraction: Option<f64>,
         exploration_budget: Option<usize>,
+        max_refit_samples: Option<usize>,
+        max_refit_candidates: Option<usize>,
     ) -> PyResult<Self> {
         if let Some(ef) = elite_fraction {
             if !ef.is_finite() || ef <= 0.0 || ef > 1.0 {
@@ -286,10 +297,25 @@ impl Gmm {
                 ));
             }
         }
+        let effective_max_refit_samples = max_refit_samples.unwrap_or(DEFAULT_MAX_REFIT_SAMPLES);
+        let effective_max_refit_candidates =
+            max_refit_candidates.unwrap_or(DEFAULT_MAX_REFIT_CANDIDATES);
+        if effective_max_refit_samples == 0 {
+            return Err(ConfigurationError::new_err(
+                "max_refit_samples must be at least 1",
+            ));
+        }
+        if effective_max_refit_candidates < effective_max_refit_samples {
+            return Err(ConfigurationError::new_err(format!(
+                "max_refit_candidates must be at least max_refit_samples ({effective_max_refit_samples}), got {effective_max_refit_candidates}",
+            )));
+        }
         Ok(Self {
             refit_interval,
             elite_fraction,
             exploration_budget,
+            max_refit_samples,
+            max_refit_candidates,
         })
     }
 }
@@ -753,6 +779,8 @@ impl Study {
                 exploration_budget: None,
                 seed,
                 elite_fraction: None,
+                max_refit_samples: DEFAULT_MAX_REFIT_SAMPLES,
+                max_refit_candidates: DEFAULT_MAX_REFIT_CANDIDATES,
             },
             Some(s) => {
                 // Extract each strategy class exactly once: probe with a single
@@ -766,6 +794,12 @@ impl Study {
                         exploration_budget: gmm.exploration_budget,
                         seed,
                         elite_fraction: gmm.elite_fraction,
+                        max_refit_samples: gmm
+                            .max_refit_samples
+                            .unwrap_or(DEFAULT_MAX_REFIT_SAMPLES),
+                        max_refit_candidates: gmm
+                            .max_refit_candidates
+                            .unwrap_or(DEFAULT_MAX_REFIT_CANDIDATES),
                     }
                 } else if s.extract::<Sobol>().is_ok() {
                     StrategyConfig {
@@ -775,6 +809,8 @@ impl Study {
                         exploration_budget: None,
                         seed,
                         elite_fraction: None,
+                        max_refit_samples: DEFAULT_MAX_REFIT_SAMPLES,
+                        max_refit_candidates: DEFAULT_MAX_REFIT_CANDIDATES,
                     }
                 } else if s.extract::<Random>().is_ok() {
                     StrategyConfig {
@@ -784,6 +820,8 @@ impl Study {
                         exploration_budget: None,
                         seed,
                         elite_fraction: None,
+                        max_refit_samples: DEFAULT_MAX_REFIT_SAMPLES,
+                        max_refit_candidates: DEFAULT_MAX_REFIT_CANDIDATES,
                     }
                 } else {
                     let name: String = s.extract().map_err(|_| {
@@ -799,6 +837,8 @@ impl Study {
                         exploration_budget: None,
                         seed,
                         elite_fraction: None,
+                        max_refit_samples: DEFAULT_MAX_REFIT_SAMPLES,
+                        max_refit_candidates: DEFAULT_MAX_REFIT_CANDIDATES,
                     }
                 }
             }
@@ -1356,14 +1396,18 @@ impl Study {
                     let metrics_dict = result.cast::<PyDict>().map_err(|_| {
                         ObjectiveError::new_err("Objective function must return a dict")
                     })?;
-                    slf.borrow(py).tell(py, trial_id, metrics_dict)?;
+                    slf.borrow(py).tell_for_run(py, trial_id, metrics_dict)?;
                     Ok(())
                 })();
                 if let Err(e) = outcome {
                     let _ = slf.borrow(py).cancel(py, trial_id);
+                    // Preserve the objective error, but leave every earlier
+                    // committed trial with a fully ranked retry receipt.
+                    let _ = slf.borrow(py).finalize_run_rankings(py);
                     return Err(e);
                 }
             }
+            slf.borrow(py).finalize_run_rankings(py)?;
         } else {
             // Parallel path: use Python's concurrent.futures.ThreadPoolExecutor
             let cf = py.import("concurrent.futures")?;
@@ -1426,7 +1470,7 @@ impl Study {
                     let metrics_dict = result.cast::<PyDict>().map_err(|_| {
                         ObjectiveError::new_err("Objective function must return a dict")
                     })?;
-                    slf.borrow(py).tell(py, trial_id, metrics_dict)?;
+                    slf.borrow(py).tell_for_run(py, trial_id, metrics_dict)?;
                     pending.swap_remove(finished_index);
                     outstanding.retain(|&id| id != trial_id);
 
@@ -1468,8 +1512,15 @@ impl Study {
             // On the failure path, surface the original objective error and
             // ignore any shutdown error. On the success path, propagate a
             // shutdown error so it is not silently swallowed.
-            outcome?;
+            if let Err(error) = outcome {
+                // Finalization is best-effort on failure so the original
+                // objective/executor error remains the one Python observes.
+                let _ = slf.borrow(py).finalize_run_rankings(py);
+                return Err(error);
+            }
+            let finalization = slf.borrow(py).finalize_run_rankings(py);
             shutdown?;
+            finalization?;
         }
 
         Ok(slf)
@@ -1533,6 +1584,41 @@ impl Study {
             StudyInner::Remote { .. } => Err(ConfigurationError::new_err(
                 "serve() is only available for local studies, not remote connections",
             )),
+        }
+    }
+}
+
+impl Study {
+    /// Internal completion path for `run()`. A local run does not expose the
+    /// per-trial `CompletedTrial`, so the engine can defer leaderboard-wide
+    /// ranking and materialize all receipts once at batch exit. Remote studies
+    /// retain the ordinary HTTP `tell` contract because no private batch
+    /// endpoint exists.
+    fn tell_for_run(
+        &self,
+        py: Python<'_>,
+        trial_id: u64,
+        metrics: &Bound<'_, PyDict>,
+    ) -> PyResult<()> {
+        match &self.inner {
+            StudyInner::Local { engine } => {
+                let raw = py_dict_to_json(metrics)?;
+                let runtime = shared_runtime()?;
+                py.detach(|| runtime.block_on(engine.tell_without_ranking(trial_id, raw)))
+                    .map_err(ObjectiveError::new_err)
+            }
+            StudyInner::Remote { .. } => self.tell(py, trial_id, metrics).map(|_| ()),
+        }
+    }
+
+    fn finalize_run_rankings(&self, py: Python<'_>) -> PyResult<()> {
+        match &self.inner {
+            StudyInner::Local { engine } => {
+                let runtime = shared_runtime()?;
+                py.detach(|| runtime.block_on(engine.finalize_deferred_rankings()))
+                    .map_err(HolaError::new_err)
+            }
+            StudyInner::Remote { .. } => Ok(()),
         }
     }
 }

--- a/hola-py/tests/test_hola.py
+++ b/hola-py/tests/test_hola.py
@@ -210,6 +210,24 @@ def test_study_strategy_gmm():
     assert study.trial_count() == 1
 
 
+def test_gmm_refit_limit_configuration_and_validation():
+    from hola_opt import ConfigurationError, Gmm, Minimize, Real, Space, Study
+
+    strategy = Gmm(max_refit_samples=17, max_refit_candidates=53)
+    assert strategy.max_refit_samples == 17
+    assert strategy.max_refit_candidates == 53
+    Study(
+        space=Space(x=Real(0.0, 1.0)),
+        objectives=[Minimize("loss")],
+        strategy=strategy,
+    )
+
+    with pytest.raises(ConfigurationError, match="max_refit_samples must be at least 1"):
+        Gmm(max_refit_samples=0)
+    with pytest.raises(ConfigurationError, match=r"at least max_refit_samples \(100\)"):
+        Gmm(max_refit_samples=100, max_refit_candidates=99)
+
+
 # ==========================================================================
 # 4. Multi-Param & Objectives
 # ==========================================================================
@@ -460,6 +478,34 @@ def test_study_run_returns_self():
     result = study.run(lambda p: {"loss": p["x"]}, n_trials=5)
     # Should return the same study object (for chaining)
     assert result is study
+
+
+def test_study_run_materializes_multiobjective_retry_receipts():
+    """run() may batch ranking internally, but every later tell replay is exact."""
+    from hola_opt import Minimize, Random, Real, Space, Study
+
+    study = Study(
+        space=Space(x=Real(0.0, 1.0), y=Real(0.0, 1.0)),
+        objectives=[Minimize("a"), Minimize("b"), Minimize("c")],
+        strategy=Random(),
+        seed=17,
+    )
+
+    study.run(
+        lambda p: {
+            "a": p["x"],
+            "b": p["y"],
+            "c": (p["x"] - p["y"]) ** 2,
+        },
+        n_trials=20,
+    )
+
+    completed = study.trials(sorted_by="index", include_infeasible=True)
+    for expected in completed:
+        replay = study.tell(expected.trial_id, expected.metrics)
+        assert replay.rank == expected.rank
+        assert replay.pareto_front == expected.pareto_front
+        assert replay.score_vector == expected.score_vector
 
 
 def test_study_run_chain_best():

--- a/hola/src/hola_engine.rs
+++ b/hola/src/hola_engine.rs
@@ -74,13 +74,14 @@ const MAX_COMPLETION_RECEIPTS: usize = 4096;
 /// after the initial warm-up. This prevents a fitted GMM from permanently
 /// collapsing around sparse early elites.
 const AUTO_EXPLORATION_PERIOD: usize = 5;
-/// Bound repeated EM work and clone volume on long studies. Elite selection
-/// still scans the leaderboard, but model fitting never grows beyond this
-/// representative top-ranked window.
-const MAX_REFIT_SAMPLES: usize = 4096;
-/// Bound the leaderboard window scanned to choose those samples, making
-/// periodic refit cost independent of total study history after warm-up.
-const MAX_REFIT_CANDIDATES: usize = 16_384;
+/// Default bound on the number of elite samples passed to full-covariance EM.
+/// This is an implementation safeguard, not part of the abstract method, and
+/// can be overridden in [`StrategyConfig`].
+pub const DEFAULT_MAX_REFIT_SAMPLES: usize = 4096;
+/// Default bound on the candidate workset ranked to choose those samples.
+/// Histories beyond this size are covered by deterministic chronological
+/// strata rather than a newest-only window.
+pub const DEFAULT_MAX_REFIT_CANDIDATES: usize = 16_384;
 
 fn unix_time_millis() -> u64 {
     SystemTime::now()
@@ -934,6 +935,9 @@ pub struct ObjectiveConfig {
     pub target: Option<f64>,
     #[serde(default)]
     pub limit: Option<f64>,
+    /// TLP score at the limit (when target and limit are configured) and
+    /// relative weight within a priority group. The TLP segment's slope is
+    /// `priority / (limit - target)`.
     #[serde(default = "default_priority")]
     pub priority: f64,
     /// Explicit priority-group label. Objectives sharing the same group are
@@ -969,10 +973,26 @@ pub struct StrategyConfig {
     /// Must be in (0.0, 1.0].
     #[serde(default)]
     pub elite_fraction: Option<f64>,
+    /// Maximum elite samples used by one GMM fit. This bounds EM cost but does
+    /// not change the abstract elite definition.
+    #[serde(default = "default_max_refit_samples")]
+    pub max_refit_samples: usize,
+    /// Maximum retained trials ranked during one elite-selection pass. Longer
+    /// histories are covered by deterministic chronological strata.
+    #[serde(default = "default_max_refit_candidates")]
+    pub max_refit_candidates: usize,
 }
 
 fn default_refit_interval() -> usize {
     20
+}
+
+fn default_max_refit_samples() -> usize {
+    DEFAULT_MAX_REFIT_SAMPLES
+}
+
+fn default_max_refit_candidates() -> usize {
+    DEFAULT_MAX_REFIT_CANDIDATES
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1186,6 +1206,15 @@ fn validate_strategy_config(strategy: &StrategyConfig) -> Result<(), String> {
             ));
         }
     }
+    if strategy.max_refit_samples == 0 {
+        return Err("strategy.max_refit_samples must be at least 1".to_string());
+    }
+    if strategy.max_refit_candidates < strategy.max_refit_samples {
+        return Err(format!(
+            "strategy.max_refit_candidates must be at least max_refit_samples ({}), got {}",
+            strategy.max_refit_samples, strategy.max_refit_candidates,
+        ));
+    }
 
     Ok(())
 }
@@ -1216,7 +1245,8 @@ pub struct CompletedTrial {
     pub metrics: serde_json::Value,
     /// Per-objective scored values after TLP/direction handling.
     /// e.g., `{"loss": 0.3, "latency": 0.8}`.
-    /// 0 = target met, (0,1) = between target and limit, inf = infeasible.
+    /// For TLP fields: 0 = target met, `priority` = at the limit, and inf =
+    /// infeasible beyond it.
     pub scores: serde_json::Value,
     /// Per-priority-group aggregated scores (objectives summed within group).
     /// This is what ranking and Pareto use.
@@ -1497,24 +1527,31 @@ impl DynLeaderboard {
         }
     }
 
-    /// Return top-k trials as (candidate, scalarized_score) for strategy refit.
+    /// Return elite trials as (candidate, strategy observation) for refitting.
+    ///
+    /// A scalar leaderboard uses its ordinary score order. A multi-group
+    /// leaderboard uses the same NSGA-II order as the public leaderboard:
+    /// lower non-domination rank first, then higher crowding distance. Both
+    /// paths rank the full retained history while it fits the configured work
+    /// bound; longer histories use deterministic chronological strata so no
+    /// newest-only bias is introduced.
     fn top_k_for_refit(
         &self,
         k: usize,
+        max_candidates: usize,
         objectives: &[ObjectiveConfig],
     ) -> Vec<(serde_json::Value, f64)> {
         match self {
             DynLeaderboard::Scalar(lb) => lb
-                .top_k_recent(k, MAX_REFIT_CANDIDATES)
+                .top_k_stratified(k, max_candidates)
                 .into_iter()
                 .map(|t| (t.candidate, t.observation))
                 .collect(),
             DynLeaderboard::Vector(lb) => lb
-                .top_k_scalarized_recent(k, MAX_REFIT_CANDIDATES, |obs| {
-                    scalarize_observation(obs, objectives)
-                })
+                .select_nsga2_stratified(k, max_candidates)
                 .into_iter()
-                .map(|t| {
+                .map(|ranked| {
+                    let t = ranked.trial;
                     (
                         t.candidate,
                         scalarize_observation(&t.observation, objectives),
@@ -1670,6 +1707,30 @@ impl DynLeaderboard {
                 let completed = build_completed_vector(trial, 0, objectives);
                 Some((completed, Some((snapshot, trial_id))))
             }
+        }
+    }
+
+    /// Build a completion payload without computing leaderboard-wide rank.
+    ///
+    /// This is only used by the local `Study.run` batch path, which never
+    /// exposes the per-completion return value. The private placeholder rank is
+    /// replaced before a receipt can be returned by the public `tell` API.
+    fn completed_without_ranking(
+        &self,
+        trial_id: u64,
+        objectives: &[ObjectiveConfig],
+    ) -> Option<CompletedTrial> {
+        match self {
+            DynLeaderboard::Scalar(lb) => Some(build_completed_scalar(
+                lb.get(trial_id)?.clone(),
+                0,
+                objectives,
+            )),
+            DynLeaderboard::Vector(lb) => Some(build_completed_vector(
+                lb.get(trial_id)?.clone(),
+                0,
+                objectives,
+            )),
         }
     }
 
@@ -2082,7 +2143,8 @@ fn f64_map_to_json(map: &BTreeMap<String, f64>) -> serde_json::Value {
 
 /// Compute per-objective TLP scores φ_i from raw metrics.
 ///
-/// Each score is P_i × normalized_distance, matching the paper's formula.
+/// Each score is P_i × normalized_distance, so P_i is its score at the limit
+/// and its relative weight within the group.
 fn compute_scores(raw: &serde_json::Value, objectives: &[ObjectiveConfig]) -> serde_json::Value {
     let mut scores = serde_json::Map::new();
     for obj in objectives {
@@ -2179,6 +2241,10 @@ pub struct HolaEngine {
     /// Cheap to clone (Arc); shared across engine clones like `state`.
     refit_lock: Arc<Mutex<()>>,
     refit_config: Option<RefitConfig>,
+    /// Implementation bound for samples passed to one GMM fit.
+    max_refit_samples: usize,
+    /// Implementation bound for trials ranked during elite selection.
+    max_refit_candidates: usize,
     auto_checkpoint: Option<AutoCheckpointConfig>,
     /// Failures from unattended auto-checkpoint writes and rotation. Shared by
     /// clones and exposed to the server metrics endpoint.
@@ -2220,11 +2286,15 @@ struct HolaEngineState {
     completion_receipts: BTreeMap<u64, CompletionReceipt>,
     /// Trial ids in commit order, used to prune the oldest receipt in O(1).
     completion_receipt_order: VecDeque<u64>,
+    /// Number of retained receipts whose public rank/front has not yet been
+    /// materialized. Local batch runners can defer that work and rank the
+    /// leaderboard once at the end instead of once per completion.
+    deferred_completion_receipts: usize,
 }
 
-/// Retry receipt for a committed tell. The exact response view and count are
-/// retained so an uncertain client can replay the operation even if a bounded
-/// leaderboard has already evicted the underlying trial.
+/// Retry receipt for a committed tell. Public tells retain the exact response
+/// view immediately. A local batch may defer its never-exposed rank/front until
+/// batch exit, while retaining the full completion payload durably.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct CompletionReceipt {
     commit_sequence: u64,
@@ -2232,6 +2302,10 @@ struct CompletionReceipt {
     committed_count: usize,
     #[serde(default)]
     post_commit_warnings: Vec<String>,
+    /// The completion payload is durable, but `rank`/`pareto_front` are private
+    /// placeholders until the first public observation of this receipt.
+    #[serde(default)]
+    ranking_deferred: bool,
 }
 
 /// Transient job state persisted alongside a full checkpoint.
@@ -2291,6 +2365,7 @@ impl HolaEngineState {
         self.lease_deadlines.clear();
         self.completion_receipts.clear();
         self.completion_receipt_order.clear();
+        self.deferred_completion_receipts = 0;
     }
 
     fn runtime_checkpoint_state(&self) -> RuntimeCheckpointState {
@@ -2450,6 +2525,11 @@ impl HolaEngineState {
                     "checkpoint completion receipt for trial_id {trial_id} has an out-of-range rank/front"
                 ));
             }
+            if receipt.ranking_deferred && !self.leaderboard.contains_trial_id(trial_id) {
+                return Err(format!(
+                    "checkpoint deferred completion receipt for trial_id {trial_id} has no retained leaderboard trial"
+                ));
+            }
             if let Some(stored_metrics) = self.leaderboard.raw_metrics(trial_id) {
                 if stored_metrics != &receipt.completed.metrics {
                     return Err(format!(
@@ -2487,6 +2567,11 @@ impl HolaEngineState {
         self.cancelled = cancelled;
         self.ask_idempotency = runtime.ask_idempotency;
         self.lease_deadlines = runtime.lease_deadlines;
+        self.deferred_completion_receipts = runtime
+            .completion_receipts
+            .values()
+            .filter(|receipt| receipt.ranking_deferred)
+            .count();
         self.completion_receipts = runtime.completion_receipts;
         self.completion_receipt_order = receipt_order
             .into_iter()
@@ -2516,6 +2601,7 @@ impl HolaEngineState {
         sequence: u64,
         completed: CompletedTrial,
         committed_count: usize,
+        ranking_deferred: bool,
     ) {
         let trial_id = completed.trial_id;
         let replaced = self.completion_receipts.insert(
@@ -2525,15 +2611,70 @@ impl HolaEngineState {
                 completed,
                 committed_count,
                 post_commit_warnings: Vec::new(),
+                ranking_deferred,
             },
         );
         debug_assert!(replaced.is_none());
+        if ranking_deferred {
+            self.deferred_completion_receipts += 1;
+        }
         self.completion_receipt_order.push_back(trial_id);
         while self.completion_receipts.len() > MAX_COMPLETION_RECEIPTS {
             if let Some(oldest_trial_id) = self.completion_receipt_order.pop_front() {
-                self.completion_receipts.remove(&oldest_trial_id);
+                if self
+                    .completion_receipts
+                    .remove(&oldest_trial_id)
+                    .is_some_and(|receipt| receipt.ranking_deferred)
+                {
+                    self.deferred_completion_receipts -= 1;
+                }
             }
         }
+    }
+
+    /// Materialize every private batch receipt against one canonical ranking
+    /// snapshot. Deferred receipts are guaranteed to remain in the leaderboard:
+    /// the batch commit path stops deferring before a bounded push can evict.
+    fn finalize_deferred_completion_receipts(&mut self) -> Result<(), String> {
+        if self.deferred_completion_receipts == 0 {
+            return Ok(());
+        }
+
+        let view_count = self.leaderboard.completed_count();
+        let current: BTreeMap<u64, CompletedTrial> = self
+            .leaderboard
+            .completed_trials("rank", true, &self.objectives)
+            .into_iter()
+            .map(|trial| (trial.trial_id, trial))
+            .collect();
+        let expected = self.deferred_completion_receipts;
+        if let Some(trial_id) = self
+            .completion_receipts
+            .iter()
+            .find_map(|(&trial_id, receipt)| {
+                (receipt.ranking_deferred && !current.contains_key(&trial_id)).then_some(trial_id)
+            })
+        {
+            return Err(format!(
+                "Deferred completion receipt for trial {trial_id} has no retained leaderboard trial"
+            ));
+        }
+        let mut finalized = 0usize;
+        for (&trial_id, receipt) in &mut self.completion_receipts {
+            if !receipt.ranking_deferred {
+                continue;
+            }
+            let completed = current
+                .get(&trial_id)
+                .expect("deferred receipt backing was checked above");
+            receipt.completed = completed.clone();
+            receipt.committed_count = view_count;
+            receipt.ranking_deferred = false;
+            finalized += 1;
+        }
+        debug_assert_eq!(finalized, expected);
+        self.deferred_completion_receipts = 0;
+        Ok(())
     }
 
     fn record_post_commit_warnings(&mut self, sequence: u64, trial_id: u64, warnings: &[String]) {
@@ -2563,6 +2704,7 @@ impl HolaEngineState {
                 // not the original commit prefix. Carry the epoch's count so
                 // every rebuilt rank/front remains internally consistent.
                 receipt.committed_count = view_count;
+                receipt.ranking_deferred = false;
                 true
             } else {
                 false
@@ -2570,6 +2712,7 @@ impl HolaEngineState {
         });
         self.completion_receipt_order
             .retain(|trial_id| self.completion_receipts.contains_key(trial_id));
+        self.deferred_completion_receipts = 0;
     }
 
     fn expire_leases(&mut self, now: u64) -> usize {
@@ -2667,6 +2810,12 @@ impl HolaEngine {
         }
 
         let refit_interval = strategy_cfg.map(|s| s.refit_interval).unwrap_or(20);
+        let max_refit_samples = strategy_cfg
+            .map(|strategy| strategy.max_refit_samples)
+            .unwrap_or(DEFAULT_MAX_REFIT_SAMPLES);
+        let max_refit_candidates = strategy_cfg
+            .map(|strategy| strategy.max_refit_candidates)
+            .unwrap_or(DEFAULT_MAX_REFIT_CANDIDATES);
         // Resolve an omitted seed exactly once. The concrete value is used by
         // every strategy and persisted in study_config/checkpoints so an
         // auto-seeded run can be reproduced rather than recording `None`.
@@ -2744,6 +2893,8 @@ impl HolaEngine {
             exploration_budget: effective_exploration_budget,
             seed: Some(seed),
             elite_fraction: effective_elite_fraction,
+            max_refit_samples,
+            max_refit_candidates,
         });
 
         let auto_checkpoint = if let Some(c) = config.checkpoint.as_ref() {
@@ -2779,9 +2930,12 @@ impl HolaEngine {
                 lease_deadlines: BTreeMap::new(),
                 completion_receipts: BTreeMap::new(),
                 completion_receipt_order: VecDeque::new(),
+                deferred_completion_receipts: 0,
             })),
             refit_lock: Arc::new(Mutex::new(())),
             refit_config,
+            max_refit_samples,
+            max_refit_candidates,
             auto_checkpoint,
             checkpoint_failures: Arc::new(AtomicU64::new(0)),
             refit_failures: Arc::new(AtomicU64::new(0)),
@@ -2969,6 +3123,48 @@ impl HolaEngine {
     where
         F: FnOnce(&CompletedTrial, usize),
     {
+        self.tell_with_outcome_mode(trial_id, raw_metrics, false, on_commit)
+            .await
+    }
+
+    /// Commit a result for a local batch runner without eagerly constructing a
+    /// ranked response that the runner will discard.
+    ///
+    /// This is intentionally hidden from the ordinary Rust API. Call
+    /// [`Self::finalize_deferred_rankings`] once the batch ends. Public
+    /// `tell()` calls remain eagerly ranked, and automatically materialize any
+    /// overlapping deferred receipts before returning one.
+    #[doc(hidden)]
+    pub async fn tell_without_ranking(
+        &self,
+        trial_id: u64,
+        raw_metrics: serde_json::Value,
+    ) -> Result<(), String> {
+        self.tell_with_outcome_mode(trial_id, raw_metrics, true, |_, _| {})
+            .await
+            .map(|_| ())
+    }
+
+    /// Materialize private batch receipts using one canonical leaderboard
+    /// ranking snapshot. This is a no-op when no batch completion is pending.
+    #[doc(hidden)]
+    pub async fn finalize_deferred_rankings(&self) -> Result<(), String> {
+        self.state
+            .write()
+            .await
+            .finalize_deferred_completion_receipts()
+    }
+
+    async fn tell_with_outcome_mode<F>(
+        &self,
+        trial_id: u64,
+        raw_metrics: serde_json::Value,
+        mut defer_ranking: bool,
+        on_commit: F,
+    ) -> Result<TellOutcome, String>
+    where
+        F: FnOnce(&CompletedTrial, usize),
+    {
         let mut state = self.state.write().await;
         state.expire_leases(unix_time_millis());
 
@@ -2982,6 +3178,12 @@ impl HolaEngine {
                     "Trial {trial_id} has already been completed with different metrics"
                 ));
             }
+            if !defer_ranking && receipt.ranking_deferred {
+                state.finalize_deferred_completion_receipts()?;
+            }
+            let receipt = state
+                .completion_receipt(trial_id)
+                .expect("finalizing receipts must preserve the requested receipt");
             return Ok(TellOutcome {
                 completed: receipt.completed.clone(),
                 trial_count: receipt.committed_count,
@@ -3017,10 +3219,27 @@ impl HolaEngine {
             });
         }
 
+        // A bounded board must never evict the backing trial for a deferred
+        // receipt. Stop deferring at the capacity boundary and materialize the
+        // prior batch before the push can evict its oldest member.
+        if !state.pending.contains_key(&trial_id) {
+            return Err(format!("Unknown trial_id: {trial_id}"));
+        }
+        let would_evict = state
+            .leaderboard
+            .max_size()
+            .is_some_and(|cap| state.leaderboard.len() >= cap);
+        if !defer_ranking || would_evict {
+            state.finalize_deferred_completion_receipts()?;
+        }
+        if would_evict {
+            defer_ranking = false;
+        }
+
         let candidate = state
             .pending
             .remove(&trial_id)
-            .ok_or_else(|| format!("Unknown trial_id: {trial_id}"))?;
+            .expect("pending membership was checked above");
         state.remove_ask_idempotency_for_trial(trial_id);
         state.lease_deadlines.remove(&trial_id);
 
@@ -3042,28 +3261,44 @@ impl HolaEngine {
         let completed_trials = state.leaderboard.completed_count();
         let commit_sequence = state.leaderboard.total_completed();
 
-        // Build the exact response and receipt before releasing the commit lock.
-        // In particular, a duplicate tell must never observe the vector path's
-        // temporary rank/front placeholders. The snapshot construction is the
-        // only part that reads the leaderboard; ranking then operates on that
-        // owned snapshot.
-        let (mut completed, vector_rank_inputs) = state
-            .leaderboard
-            .completed_for_tell(stored_trial_id, true, &objectives)
-            .ok_or_else(|| format!("Failed to build CompletedTrial for {stored_trial_id}"))?;
-        if let Some((participants, target)) = vector_rank_inputs {
-            let (rank, front) = vector_dashboard_rank(&participants, target)
-                .ok_or_else(|| format!("Failed to rank CompletedTrial for {stored_trial_id}"))?;
-            completed.rank = rank;
-            completed.pareto_front = front;
-        }
-        state.record_completion_receipt(commit_sequence, completed.clone(), completed_trials);
+        // Public tells build their exact response before releasing the commit
+        // lock. The local batch path stores only the completion payload; its
+        // private placeholder rank/front is materialized before any public
+        // replay and once at normal batch exit.
+        let completed = if defer_ranking {
+            state
+                .leaderboard
+                .completed_without_ranking(stored_trial_id, &objectives)
+                .ok_or_else(|| format!("Failed to build CompletedTrial for {stored_trial_id}"))?
+        } else {
+            let (mut completed, vector_rank_inputs) = state
+                .leaderboard
+                .completed_for_tell(stored_trial_id, true, &objectives)
+                .ok_or_else(|| format!("Failed to build CompletedTrial for {stored_trial_id}"))?;
+            if let Some((participants, target)) = vector_rank_inputs {
+                let (rank, front) =
+                    vector_dashboard_rank(&participants, target).ok_or_else(|| {
+                        format!("Failed to rank CompletedTrial for {stored_trial_id}")
+                    })?;
+                completed.rank = rank;
+                completed.pareto_front = front;
+            }
+            completed
+        };
+        state.record_completion_receipt(
+            commit_sequence,
+            completed.clone(),
+            completed_trials,
+            defer_ranking,
+        );
         drop(state);
 
         // There is deliberately no `.await` between recording the receipt and
         // this hook. Cancellation therefore observes either neither operation
         // or both the commit and its externally visible event.
-        on_commit(&completed, completed_trials);
+        if !defer_ranking {
+            on_commit(&completed, completed_trials);
+        }
 
         // Own post-commit maintenance in a spawned task. Awaiting it preserves
         // the synchronous API's warnings on the normal path, while dropping or
@@ -3126,11 +3361,13 @@ impl HolaEngine {
                 let refit_completed = state_guard.leaderboard.completed_count();
                 let k = config
                     .selection_count(refit_completed)
-                    .min(MAX_REFIT_SAMPLES);
+                    .min(self.max_refit_samples);
                 let refit_objectives = state_guard.objectives.clone();
-                let trials = state_guard
-                    .leaderboard
-                    .top_k_for_refit(k, &refit_objectives);
+                let trials = state_guard.leaderboard.top_k_for_refit(
+                    k,
+                    self.max_refit_candidates,
+                    &refit_objectives,
+                );
                 let mut strategy_snapshot = state_guard.strategy.clone();
                 let space_clone = self.space.clone();
                 drop(state_guard);
@@ -3483,9 +3720,12 @@ impl HolaEngine {
         }
         let k = config
             .selection_count(current_completed)
-            .min(MAX_REFIT_SAMPLES);
+            .min(self.max_refit_samples);
         let objectives = state_guard.objectives.clone();
-        let trials = state_guard.leaderboard.top_k_for_refit(k, &objectives);
+        let trials =
+            state_guard
+                .leaderboard
+                .top_k_for_refit(k, self.max_refit_candidates, &objectives);
         let mut strategy_snapshot = state_guard.strategy.clone();
         let space_clone = self.space.clone();
         drop(state_guard);
@@ -3640,6 +3880,8 @@ impl HolaEngine {
         let current_is_vector = count_priority_groups(&objectives) > 1;
         let space = self.space.clone();
         let max_leaderboard_size = self.max_leaderboard_size;
+        let max_refit_samples = self.max_refit_samples;
+        let max_refit_candidates = self.max_refit_candidates;
         let (leaderboard, strategy, n) = tokio::task::spawn_blocking(move || {
             let mut leaderboard = parse_leaderboard_checkpoint(raw, current_is_vector)?;
             leaderboard
@@ -3649,8 +3891,11 @@ impl HolaEngine {
             let n = leaderboard.len();
             leaderboard.set_max_size(max_leaderboard_size);
             let completed_count = leaderboard.completed_count();
-            let trials =
-                leaderboard.top_k_for_refit(completed_count.min(MAX_REFIT_SAMPLES), &objectives);
+            let trials = leaderboard.top_k_for_refit(
+                completed_count.min(max_refit_samples),
+                max_refit_candidates,
+                &objectives,
+            );
             let mut strategy = strategy;
             strategy
                 .reconcile_imported_history(&space, completed_count, &trials)
@@ -3893,6 +4138,7 @@ impl HolaEngine {
                 lease_deadlines: BTreeMap::new(),
                 completion_receipts: BTreeMap::new(),
                 completion_receipt_order: VecDeque::new(),
+                deferred_completion_receipts: 0,
             };
             replacement.leaderboard.set_max_size(max_leaderboard_size);
             replacement
@@ -4088,7 +4334,8 @@ fn parse_leaderboard_checkpoint(
 ///
 /// Implements the paper's formula: F(x) = Σ φ_i(f_i(x)) where
 /// φ_i(u) = P_i × (u − T_i)/(L_i − T_i) for the in-range case.
-/// Each objective's TLP score is multiplied by its priority weight P_i.
+/// Each objective's normalized TLP score is multiplied by its priority P_i,
+/// which is the resulting score at the limit and relative weight in its group.
 fn scalarize_raw(raw: &serde_json::Value, objectives: &[ObjectiveConfig]) -> f64 {
     let mut total = 0.0;
     for obj in objectives {
@@ -4109,8 +4356,9 @@ fn scalarize_raw(raw: &serde_json::Value, objectives: &[ObjectiveConfig]) -> f64
 /// Compute per-group cost vector C(x) from raw metrics.
 ///
 /// Groups objectives by their explicit group label. Within each group,
-/// the group cost is: C_g(x) = Σ_{i ∈ G_g} P_i × φ_i(f_i(x))
-/// where P_i is the per-objective priority weight.
+/// the group cost is C_g(x) = Σ_{i ∈ G_g} φ_i(f_i(x)), where each
+/// paper-defined TLP score φ_i already includes its priority P_i. The code
+/// below forms that score as P_i times the unweighted normalized distance.
 fn vectorize_raw(raw: &serde_json::Value, objectives: &[ObjectiveConfig]) -> BTreeMap<String, f64> {
     let mut groups: BTreeMap<String, f64> = BTreeMap::new();
     for obj in objectives {
@@ -4147,7 +4395,8 @@ fn group_key(obj: &ObjectiveConfig) -> String {
     obj.group.clone().unwrap_or_else(|| obj.field.clone())
 }
 
-/// Compute TLP score for a single value (shared by scalarize_raw and vectorize_raw).
+/// Compute normalized TLP score for a single value (shared by `scalarize_raw`
+/// and `vectorize_raw`).
 fn objective_score(val: f64, obj_type: &str, target: Option<f64>, limit: Option<f64>) -> f64 {
     match obj_type {
         "minimize" => match (target, limit) {
@@ -4250,6 +4499,80 @@ mod tests {
                 &shared,
             ),
             serde_json::json!({"quality": 5.0})
+        );
+    }
+
+    #[test]
+    fn test_vector_refit_elites_use_group_cost_pareto_rank_and_crowding() {
+        let objectives = vec![
+            ObjectiveConfig {
+                field: "error".to_string(),
+                obj_type: "minimize".to_string(),
+                target: None,
+                limit: None,
+                priority: 2.0,
+                group: Some("quality".to_string()),
+            },
+            ObjectiveConfig {
+                field: "calibration".to_string(),
+                obj_type: "minimize".to_string(),
+                target: None,
+                limit: None,
+                priority: 0.5,
+                group: Some("quality".to_string()),
+            },
+            ObjectiveConfig {
+                field: "latency".to_string(),
+                obj_type: "minimize".to_string(),
+                target: None,
+                limit: None,
+                priority: 1.0,
+                group: Some("cost".to_string()),
+            },
+        ];
+        let mut leaderboard = DynLeaderboard::for_objectives(&objectives);
+
+        for (trial_id, candidate, metrics) in [
+            (
+                0,
+                "quality-boundary",
+                serde_json::json!({"error": 0.0, "calibration": 0.0, "latency": 10.0}),
+            ),
+            (
+                1,
+                "summed-cost-winner",
+                serde_json::json!({"error": 1.0, "calibration": 4.0, "latency": 4.0}),
+            ),
+            (
+                2,
+                "cost-boundary",
+                serde_json::json!({"error": 5.0, "calibration": 0.0, "latency": 0.0}),
+            ),
+        ] {
+            leaderboard.push_with_raw(
+                trial_id,
+                serde_json::json!({"candidate": candidate}),
+                metrics,
+                &objectives,
+            );
+        }
+
+        let middle = vectorize_raw(
+            &serde_json::json!({"error": 1.0, "calibration": 4.0, "latency": 4.0}),
+            &objectives,
+        );
+        assert_eq!(middle["quality"], 4.0);
+        assert_eq!(middle["cost"], 4.0);
+
+        let elites = leaderboard.top_k_for_refit(2, DEFAULT_MAX_REFIT_CANDIDATES, &objectives);
+        let names: Vec<&str> = elites
+            .iter()
+            .map(|(candidate, _)| candidate["candidate"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["quality-boundary", "cost-boundary"]);
+        assert!(
+            !names.contains(&"summed-cost-winner"),
+            "the summed-cost winner is an interior Pareto point and must lose the two-slot crowding tie-break"
         );
     }
 
@@ -4622,6 +4945,18 @@ mod tests {
     }
 
     #[test]
+    fn test_strategy_config_legacy_json_uses_refit_limit_defaults() {
+        let strategy: StrategyConfig = serde_json::from_value(serde_json::json!({
+            "type": "gmm",
+            "refit_interval": 20
+        }))
+        .unwrap();
+        assert_eq!(strategy.max_refit_samples, DEFAULT_MAX_REFIT_SAMPLES);
+        assert_eq!(strategy.max_refit_candidates, DEFAULT_MAX_REFIT_CANDIDATES);
+        validate_strategy_config(&strategy).unwrap();
+    }
+
+    #[test]
     fn test_dyn_space_builder_api() {
         let space = DynSpace::new()
             .add_real("x", 0.0, 1.0)
@@ -4955,6 +5290,8 @@ mod tests {
                 exploration_budget: None,
                 seed: None,
                 elite_fraction: None,
+                max_refit_samples: 4096,
+                max_refit_candidates: 16_384,
             })
         };
         let study = |n: usize, ty: &str| StudyConfig {
@@ -5024,6 +5361,8 @@ mod tests {
                 exploration_budget: None,
                 seed: Some(7),
                 elite_fraction: None,
+                max_refit_samples: 4096,
+                max_refit_candidates: 16_384,
             }),
             checkpoint: None,
             max_trials: None,
@@ -5048,6 +5387,39 @@ mod tests {
         let original_trial = engine.ask().await.unwrap();
         let reproduced_trial = reproduced.ask().await.unwrap();
         assert_eq!(original_trial.params, reproduced_trial.params);
+    }
+
+    #[tokio::test]
+    async fn test_refit_limits_are_exported_and_persisted_in_full_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let checkpoint_path = dir.path().join("refit-limits.json");
+        let mut config = single_objective_config("gmm");
+        let strategy = config.strategy.as_mut().unwrap();
+        strategy.max_refit_samples = 17;
+        strategy.max_refit_candidates = 53;
+
+        let engine = HolaEngine::from_config(config).unwrap();
+        let exported = engine.study_config().await;
+        let exported_strategy = exported.strategy.as_ref().unwrap();
+        assert_eq!(exported_strategy.max_refit_samples, 17);
+        assert_eq!(exported_strategy.max_refit_candidates, 53);
+
+        engine
+            .save_full_checkpoint(&checkpoint_path, None)
+            .await
+            .unwrap();
+        let checkpoint: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&checkpoint_path).unwrap()).unwrap();
+        assert_eq!(checkpoint["config"]["strategy"]["max_refit_samples"], 17);
+        assert_eq!(checkpoint["config"]["strategy"]["max_refit_candidates"], 53);
+
+        let restored = HolaEngine::load_from_checkpoint(&checkpoint_path)
+            .await
+            .unwrap();
+        let restored_config = restored.study_config().await;
+        let restored_strategy = restored_config.strategy.unwrap();
+        assert_eq!(restored_strategy.max_refit_samples, 17);
+        assert_eq!(restored_strategy.max_refit_candidates, 53);
     }
 
     #[tokio::test]
@@ -5945,7 +6317,11 @@ mod tests {
                 refit_at.push(cadence);
                 assert_eq!(
                     leaderboard
-                        .top_k_for_refit(config.selection_count(cadence), &objectives)
+                        .top_k_for_refit(
+                            config.selection_count(cadence),
+                            DEFAULT_MAX_REFIT_CANDIDATES,
+                            &objectives,
+                        )
                         .len(),
                     2
                 );
@@ -5982,19 +6358,315 @@ mod tests {
             }
             let leaderboard = DynLeaderboard::Scalar(inner);
             let started = Instant::now();
-            let workset = black_box(leaderboard.top_k_for_refit(MAX_REFIT_SAMPLES, &objectives));
+            let workset = black_box(leaderboard.top_k_for_refit(
+                DEFAULT_MAX_REFIT_SAMPLES,
+                DEFAULT_MAX_REFIT_CANDIDATES,
+                &objectives,
+            ));
             let elapsed = started.elapsed();
 
-            assert_eq!(workset.len(), history_size.min(MAX_REFIT_SAMPLES));
-            assert!(workset.len() <= MAX_REFIT_SAMPLES);
+            assert_eq!(workset.len(), history_size.min(DEFAULT_MAX_REFIT_SAMPLES));
+            assert!(workset.len() <= DEFAULT_MAX_REFIT_SAMPLES);
             assert!(
                 elapsed < std::time::Duration::from_secs(5),
                 "bounded refit selection exceeded the 5s debug budget at history={history_size}: {elapsed:?}"
             );
             eprintln!(
-                "history={history_size}, scanned_at_most={MAX_REFIT_CANDIDATES}, workset={}, selection={elapsed:?}",
+                "history={history_size}, covered_at_most={DEFAULT_MAX_REFIT_CANDIDATES}, workset={}, selection={elapsed:?}",
                 workset.len()
             );
+        }
+    }
+
+    #[test]
+    #[ignore = "performance probe; run explicitly with --ignored --nocapture"]
+    fn multiobjective_refit_selection_scaling_probe() {
+        use std::hint::black_box;
+        use std::time::{Duration, Instant};
+
+        const HISTORY_SIZE: usize = 1_000;
+        const ELITE_COUNT: usize = 250;
+        for group_count in [2usize, 3, 5] {
+            let objectives: Vec<ObjectiveConfig> = (0..group_count)
+                .map(|group| ObjectiveConfig {
+                    field: format!("metric-{group}"),
+                    obj_type: "minimize".to_string(),
+                    target: None,
+                    limit: None,
+                    priority: 1.0,
+                    group: Some(format!("group-{group}")),
+                })
+                .collect();
+            let mut inner = Leaderboard::with_capacity(HISTORY_SIZE);
+            for trial in 0..HISTORY_SIZE {
+                let mut observation = BTreeMap::new();
+                observation.insert("group-0".to_string(), trial as f64);
+                observation.insert("group-1".to_string(), (HISTORY_SIZE - trial) as f64);
+                for group in 2..group_count {
+                    observation.insert(
+                        format!("group-{group}"),
+                        ((trial.wrapping_mul(37 + group)) % HISTORY_SIZE) as f64,
+                    );
+                }
+                inner.push(serde_json::json!({"trial": trial}), observation);
+            }
+            let leaderboard = DynLeaderboard::Vector(inner);
+
+            let started = Instant::now();
+            let elites =
+                black_box(leaderboard.top_k_for_refit(ELITE_COUNT, HISTORY_SIZE, &objectives));
+            let elapsed = started.elapsed();
+            assert_eq!(elites.len(), ELITE_COUNT);
+            assert!(
+                elapsed < Duration::from_secs(5),
+                "{group_count}-group NSGA-II selection exceeded the debug-build budget: {elapsed:?}"
+            );
+            eprintln!(
+                "N={HISTORY_SIZE}, groups={group_count}, elites={ELITE_COUNT}, selection={elapsed:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn deferred_batch_rankings_materialize_and_replay_exactly() {
+        let mut config = single_objective_config("random");
+        config.objectives = (0..3)
+            .map(|group| ObjectiveConfig {
+                field: format!("metric-{group}"),
+                obj_type: "minimize".to_string(),
+                target: None,
+                limit: None,
+                priority: 1.0,
+                group: Some(format!("group-{group}")),
+            })
+            .collect();
+        let engine = HolaEngine::from_config(config).unwrap();
+        let mut completions = Vec::new();
+        for index in 0..24u64 {
+            let trial = engine.ask().await.unwrap();
+            let metrics = serde_json::json!({
+                "metric-0": (index * 17 % 23) as f64,
+                "metric-1": ((23 - index) * 11 % 29) as f64,
+                "metric-2": (index * index % 31) as f64,
+            });
+            engine
+                .tell_without_ranking(trial.trial_id, metrics.clone())
+                .await
+                .unwrap();
+            completions.push((trial.trial_id, metrics));
+        }
+
+        {
+            let state = engine.state.read().await;
+            assert_eq!(state.deferred_completion_receipts, completions.len());
+            assert!(
+                state
+                    .completion_receipts
+                    .values()
+                    .all(|receipt| receipt.ranking_deferred)
+            );
+        }
+
+        engine.finalize_deferred_rankings().await.unwrap();
+        let final_view: BTreeMap<u64, CompletedTrial> = engine
+            .trials("rank", true)
+            .await
+            .into_iter()
+            .map(|trial| (trial.trial_id, trial))
+            .collect();
+        {
+            let state = engine.state.read().await;
+            assert_eq!(state.deferred_completion_receipts, 0);
+            assert!(
+                state
+                    .completion_receipts
+                    .values()
+                    .all(|receipt| !receipt.ranking_deferred)
+            );
+        }
+
+        for (trial_id, metrics) in completions {
+            let replay = engine.tell_with_outcome(trial_id, metrics).await.unwrap();
+            let expected = &final_view[&trial_id];
+            assert!(!replay.newly_committed);
+            assert_eq!(replay.completed.rank, expected.rank);
+            assert_eq!(replay.completed.pareto_front, expected.pareto_front);
+            assert_eq!(replay.completed.score_vector, expected.score_vector);
+        }
+    }
+
+    #[tokio::test]
+    async fn public_tell_materializes_a_deferred_batch_before_replay() {
+        let mut config = single_objective_config("random");
+        config.objectives = vec![
+            ObjectiveConfig {
+                field: "a".to_string(),
+                obj_type: "minimize".to_string(),
+                target: None,
+                limit: None,
+                priority: 1.0,
+                group: Some("a".to_string()),
+            },
+            ObjectiveConfig {
+                field: "b".to_string(),
+                obj_type: "minimize".to_string(),
+                target: None,
+                limit: None,
+                priority: 1.0,
+                group: Some("b".to_string()),
+            },
+            ObjectiveConfig {
+                field: "c".to_string(),
+                obj_type: "minimize".to_string(),
+                target: None,
+                limit: None,
+                priority: 1.0,
+                group: Some("c".to_string()),
+            },
+        ];
+        let engine = HolaEngine::from_config(config).unwrap();
+        let mut completions = Vec::new();
+        for index in 0..5u64 {
+            let trial = engine.ask().await.unwrap();
+            let metrics = serde_json::json!({
+                "a": index as f64,
+                "b": (5 - index) as f64,
+                "c": (index * 3 % 5) as f64,
+            });
+            engine
+                .tell_without_ranking(trial.trial_id, metrics.clone())
+                .await
+                .unwrap();
+            completions.push((trial.trial_id, metrics));
+        }
+
+        let (trial_id, metrics) = completions[2].clone();
+        let replay = engine.tell_with_outcome(trial_id, metrics).await.unwrap();
+        assert!(!replay.newly_committed);
+        assert_eq!(engine.state.read().await.deferred_completion_receipts, 0);
+        let current = engine.completed_trial(trial_id, true).await.unwrap();
+        assert_eq!(replay.completed.rank, current.rank);
+        assert_eq!(replay.completed.pareto_front, current.pareto_front);
+    }
+
+    #[tokio::test]
+    async fn bounded_batch_never_evicts_an_unranked_receipt() {
+        let mut config = single_objective_config("random");
+        config.max_leaderboard_size = Some(2);
+        let engine = HolaEngine::from_config(config).unwrap();
+        let mut completions = Vec::new();
+        for loss in [0.4, 0.2, 0.3] {
+            let trial = engine.ask().await.unwrap();
+            let metrics = serde_json::json!({"loss": loss});
+            engine
+                .tell_without_ranking(trial.trial_id, metrics.clone())
+                .await
+                .unwrap();
+            completions.push((trial.trial_id, metrics));
+        }
+
+        let state = engine.state.read().await;
+        assert_eq!(state.leaderboard.len(), 2);
+        assert_eq!(state.deferred_completion_receipts, 0);
+        assert!(
+            state
+                .completion_receipts
+                .values()
+                .all(|receipt| !receipt.ranking_deferred)
+        );
+        drop(state);
+
+        // The first trial has left the bounded leaderboard, so this successful
+        // replay proves its exact receipt was materialized before eviction.
+        let replay = engine
+            .tell_with_outcome(completions[0].0, completions[0].1.clone())
+            .await
+            .unwrap();
+        assert!(!replay.newly_committed);
+        assert_eq!(replay.completed.trial_id, completions[0].0);
+    }
+
+    #[tokio::test]
+    async fn deferred_receipts_round_trip_through_a_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("deferred.json");
+        let engine = HolaEngine::from_config(single_objective_config("random")).unwrap();
+        let mut completions = Vec::new();
+        for loss in [0.8, 0.1, 0.5] {
+            let trial = engine.ask().await.unwrap();
+            let metrics = serde_json::json!({"loss": loss});
+            engine
+                .tell_without_ranking(trial.trial_id, metrics.clone())
+                .await
+                .unwrap();
+            completions.push((trial.trial_id, metrics));
+        }
+        engine.save(path.to_str().unwrap()).await.unwrap();
+
+        let restored = HolaEngine::load_from_checkpoint(path.to_str().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            restored.state.read().await.deferred_completion_receipts,
+            completions.len()
+        );
+        restored.finalize_deferred_rankings().await.unwrap();
+        let replay = restored
+            .tell_with_outcome(completions[1].0, completions[1].1.clone())
+            .await
+            .unwrap();
+        assert!(!replay.newly_committed);
+        assert_eq!(replay.completed.rank, 0);
+    }
+
+    #[tokio::test]
+    #[ignore = "performance probe; run explicitly with --ignored --nocapture"]
+    async fn deferred_multiobjective_batch_scaling_probe() {
+        use std::time::Instant;
+
+        for group_count in [3usize, 5] {
+            for sample_count in [100usize, 200, 500, 1_000] {
+                let mut config = single_objective_config("random");
+                config.objectives = (0..group_count)
+                    .map(|group| ObjectiveConfig {
+                        field: format!("metric-{group}"),
+                        obj_type: "minimize".to_string(),
+                        target: None,
+                        limit: None,
+                        priority: 1.0,
+                        group: Some(format!("group-{group}")),
+                    })
+                    .collect();
+                let engine = HolaEngine::from_config(config).unwrap();
+                let started = Instant::now();
+                for index in 0..sample_count {
+                    let trial = engine.ask().await.unwrap();
+                    let metrics = serde_json::Value::Object(
+                        (0..group_count)
+                            .map(|group| {
+                                (
+                                    format!("metric-{group}"),
+                                    serde_json::json!(
+                                        (index.wrapping_mul(37 + group) % sample_count) as f64
+                                    ),
+                                )
+                            })
+                            .collect(),
+                    );
+                    engine
+                        .tell_without_ranking(trial.trial_id, metrics)
+                        .await
+                        .unwrap();
+                }
+                let commits = started.elapsed();
+                let finalize_started = Instant::now();
+                engine.finalize_deferred_rankings().await.unwrap();
+                let finalize = finalize_started.elapsed();
+                eprintln!(
+                    "N={sample_count}, groups={group_count}, commits={commits:?}, finalize={finalize:?}, total={:?}",
+                    started.elapsed()
+                );
+            }
         }
     }
 

--- a/hola/src/lib.rs
+++ b/hola/src/lib.rs
@@ -30,6 +30,7 @@ pub mod server;
 
 // Re-export at crate root for convenience
 pub use hola_engine::{
-    AutoStrategy, CompletedTrial, DynSpace, DynTrial, HolaEngine, ObjectiveConfig, ParamConfig,
-    ParamInfo, StrategyConfig, StudyConfig,
+    AutoStrategy, CompletedTrial, DEFAULT_MAX_REFIT_CANDIDATES, DEFAULT_MAX_REFIT_SAMPLES,
+    DynSpace, DynTrial, HolaEngine, ObjectiveConfig, ParamConfig, ParamInfo, StrategyConfig,
+    StudyConfig,
 };

--- a/hola/tests/integration/end_to_end.rs
+++ b/hola/tests/integration/end_to_end.rs
@@ -100,6 +100,8 @@ async fn test_seeded_gmm_meets_sphere_quality_baseline() {
                 exploration_budget: None,
                 seed: Some(seed),
                 elite_fraction: None,
+                max_refit_samples: 4096,
+                max_refit_candidates: 16_384,
             }),
             checkpoint: None,
             max_trials: Some(500),

--- a/hola/tests/integration/hola_engine.rs
+++ b/hola/tests/integration/hola_engine.rs
@@ -115,6 +115,8 @@ fn valid_config_for_validation() -> StudyConfig {
             exploration_budget: None,
             seed: None,
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,
@@ -244,6 +246,29 @@ fn test_dyn_engine_config_validation_rejects_invalid_refit_and_priority() {
     let mut elite_fraction = valid_config_for_validation();
     elite_fraction.strategy.as_mut().unwrap().elite_fraction = Some(f64::NAN);
     assert_config_error(elite_fraction, &["strategy.elite_fraction", "finite"]);
+
+    let mut zero_fit_samples = valid_config_for_validation();
+    zero_fit_samples
+        .strategy
+        .as_mut()
+        .unwrap()
+        .max_refit_samples = 0;
+    assert_config_error(
+        zero_fit_samples,
+        &["strategy.max_refit_samples", "at least 1"],
+    );
+
+    let mut undersized_candidate_workset = valid_config_for_validation();
+    let strategy = undersized_candidate_workset.strategy.as_mut().unwrap();
+    strategy.max_refit_samples = 100;
+    strategy.max_refit_candidates = 99;
+    assert_config_error(
+        undersized_candidate_workset,
+        &[
+            "strategy.max_refit_candidates",
+            "at least max_refit_samples (100)",
+        ],
+    );
 }
 
 // ==========================================================================
@@ -627,6 +652,8 @@ async fn test_dyn_engine_strategy_types() {
             exploration_budget: None,
             seed: None,
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,
@@ -660,6 +687,8 @@ async fn test_dyn_engine_strategy_types() {
             exploration_budget: None,
             seed: None,
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,
@@ -1213,6 +1242,8 @@ async fn test_dyn_engine_gmm_with_refit() {
             exploration_budget: None,
             seed: None,
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,
@@ -1258,6 +1289,8 @@ async fn test_refit_excludes_infeasible_scalar() {
             exploration_budget: None,
             seed: None,
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,
@@ -1309,6 +1342,8 @@ async fn test_update_objectives_triggers_refit() {
             exploration_budget: None,
             seed: None,
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,
@@ -1394,6 +1429,8 @@ async fn test_dyn_engine_concurrent_refit_serialization() {
             exploration_budget: Some(4),
             seed: Some(7),
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,
@@ -1768,6 +1805,8 @@ async fn test_full_version_one_checkpoint_migrates_without_runtime_state() {
         exploration_budget: None,
         seed: Some(17),
         elite_fraction: None,
+        max_refit_samples: 4096,
+        max_refit_candidates: 16_384,
     });
     let engine = HolaEngine::from_config(config).unwrap();
     let first = engine.ask().await.unwrap();
@@ -1974,6 +2013,8 @@ async fn leaderboard_reimport_uses_completed_count_not_sparse_trial_ids_as_sampl
             exploration_budget: Some(10),
             seed: Some(73),
             elite_fraction: Some(0.5),
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         });
 
         // Establish the deterministic fifth sample for this strategy after four
@@ -2067,6 +2108,8 @@ fn auto_strategy_test_config(exploration_budget: usize, seed: u64) -> StudyConfi
             exploration_budget: Some(exploration_budget),
             seed: Some(seed),
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,
@@ -2083,6 +2126,8 @@ fn sobol_strategy_test_config(seed: u64) -> StudyConfig {
         exploration_budget: None,
         seed: Some(seed),
         elite_fraction: None,
+        max_refit_samples: 4096,
+        max_refit_candidates: 16_384,
     });
     config
 }
@@ -2157,6 +2202,8 @@ async fn test_auto_strategy_with_explicit_exploration_budget() {
             exploration_budget: Some(10), // switch to GMM after 10 trials
             seed: None,
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,
@@ -2274,6 +2321,8 @@ async fn test_seed_determinism_sobol() {
                 exploration_budget: None,
                 seed: Some(seed),
                 elite_fraction: None,
+                max_refit_samples: 4096,
+                max_refit_candidates: 16_384,
             }),
             checkpoint: None,
             max_trials: None,
@@ -2322,6 +2371,8 @@ async fn test_seed_determinism_random() {
                 exploration_budget: None,
                 seed: Some(seed),
                 elite_fraction: None,
+                max_refit_samples: 4096,
+                max_refit_candidates: 16_384,
             }),
             checkpoint: None,
             max_trials: None,
@@ -2383,6 +2434,8 @@ async fn test_pareto_front_multi_objective() {
             exploration_budget: None,
             seed: Some(0),
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,
@@ -2453,6 +2506,8 @@ async fn test_live_vector_ranks_respect_direction_and_never_promote_infeasible_t
             exploration_budget: None,
             seed: Some(7),
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,
@@ -2619,6 +2674,8 @@ fn concurrency_test_config() -> StudyConfig {
             exploration_budget: Some(8),
             seed: Some(7),
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,

--- a/hola/tests/integration/server.rs
+++ b/hola/tests/integration/server.rs
@@ -75,6 +75,8 @@ fn sobol_config(seed: u64) -> StudyConfig {
             exploration_budget: None,
             seed: Some(seed),
             elite_fraction: None,
+            max_refit_samples: 4096,
+            max_refit_candidates: 16_384,
         }),
         checkpoint: None,
         max_trials: None,

--- a/opt_engine/src/leaderboard.rs
+++ b/opt_engine/src/leaderboard.rs
@@ -621,10 +621,45 @@ impl<D: Clone> Leaderboard<D, f64> {
         feasible.into_iter().cloned().collect()
     }
 
+    /// Return the best `k` feasible trials from a deterministic, stratified
+    /// sample of the retained feasible history.
+    ///
+    /// Feasible histories no larger than `max_candidates` are ranked globally
+    /// without approximation. Larger feasible histories contribute one
+    /// midpoint from each equal-sized chronological stratum, avoiding the
+    /// recency bias of a newest-only window while bounding repeated selection
+    /// work. Infeasible trials do not consume the candidate budget.
+    pub fn top_k_stratified(&self, k: usize, max_candidates: usize) -> Vec<Trial<D, f64>> {
+        if self.trials.is_empty() || k == 0 || max_candidates == 0 {
+            return Vec::new();
+        }
+        let feasible_history: Vec<&Trial<D, f64>> = self
+            .trials
+            .iter()
+            .filter(|trial| Self::trial_is_feasible(trial))
+            .collect();
+        let mut feasible: Vec<&Trial<D, f64>> =
+            stratified_history_indices(feasible_history.len(), max_candidates)
+                .into_iter()
+                .map(|index| feasible_history[index])
+                .collect();
+        let limit = k.min(feasible.len());
+        if limit < feasible.len() {
+            feasible.select_nth_unstable_by(limit, |a, b| Self::compare_best(a, b));
+            feasible.truncate(limit);
+        }
+        feasible.sort_by(|a, b| Self::compare_best(a, b));
+        feasible.into_iter().cloned().collect()
+    }
+
     /// Return the best `k` feasible trials from at most the most recent
-    /// `max_candidates` entries. This bounds repeated selection work for
-    /// long-running refit loops while retaining deterministic partial
-    /// selection within the chosen window.
+    /// `max_candidates` entries.
+    ///
+    /// This method preserves the historical newest-window behavior for source
+    /// and semantic compatibility. Refit callers should generally prefer
+    /// [`Self::top_k_stratified`], which covers the full feasible history
+    /// without recency bias.
+    #[deprecated(note = "use top_k_stratified for full-history coverage")]
     pub fn top_k_recent(&self, k: usize, max_candidates: usize) -> Vec<Trial<D, f64>> {
         if self.trials.is_empty() || k == 0 || max_candidates == 0 {
             return Vec::new();
@@ -801,6 +836,81 @@ impl<D: Clone> Leaderboard<D, f64> {
 
 type ScoredMultiTrial<'a, D> = (&'a Trial<D, BTreeMap<String, f64>>, f64);
 
+/// Select at most `maximum` indices with deterministic coverage of a complete
+/// chronological history. Each non-empty stratum contributes its midpoint.
+fn stratified_history_indices(length: usize, maximum: usize) -> Vec<usize> {
+    if length == 0 || maximum == 0 {
+        return Vec::new();
+    }
+    if length <= maximum {
+        return (0..length).collect();
+    }
+
+    let base_size = length / maximum;
+    let larger_strata = length % maximum;
+    let mut start = 0usize;
+    let mut indices = Vec::with_capacity(maximum);
+    for stratum in 0..maximum {
+        let size = base_size + usize::from(stratum < larger_strata);
+        indices.push(start + size / 2);
+        start += size;
+    }
+    debug_assert_eq!(start, length);
+    indices
+}
+
+/// Flatten a rectangular, finite objective table for allocation-free pairwise
+/// dominance checks. Malformed or heterogeneous maps fall back to the general
+/// map-merging comparison.
+fn dense_objective_matrix<D>(
+    trials: &[Trial<D, BTreeMap<String, f64>>],
+) -> Option<(usize, Vec<f64>)> {
+    let first = trials.first()?;
+    let keys: Vec<&str> = first.observation.keys().map(String::as_str).collect();
+    if keys.is_empty() {
+        return None;
+    }
+
+    let mut values = Vec::with_capacity(trials.len().checked_mul(keys.len())?);
+    for trial in trials {
+        if trial.observation.len() != keys.len() {
+            return None;
+        }
+        for key in &keys {
+            let value = *trial.observation.get(*key)?;
+            if !value.is_finite() {
+                return None;
+            }
+            values.push(value);
+        }
+    }
+    Some((keys.len(), values))
+}
+
+/// Compare two aligned finite objective vectors in one pass. `Less` means `a`
+/// dominates `b`, `Greater` means `b` dominates `a`, and `Equal` means neither
+/// dominates (including an exact tie).
+#[inline]
+fn dense_dominance_relation(a: &[f64], b: &[f64]) -> Ordering {
+    let mut a_better = false;
+    let mut b_better = false;
+    for (&a_value, &b_value) in a.iter().zip(b) {
+        if a_value < b_value {
+            a_better = true;
+        } else if b_value < a_value {
+            b_better = true;
+        }
+        if a_better && b_better {
+            return Ordering::Equal;
+        }
+    }
+    match (a_better, b_better) {
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        _ => Ordering::Equal,
+    }
+}
+
 impl<D: Clone> Leaderboard<D, BTreeMap<String, f64>> {
     /// Check if a trial is feasible (all objective values are finite).
     ///
@@ -839,15 +949,43 @@ impl<D: Clone> Leaderboard<D, BTreeMap<String, f64>> {
     /// - both NaN is a tie in that objective.
     fn dominates(a: &BTreeMap<String, f64>, b: &BTreeMap<String, f64>) -> bool {
         let mut dominated_some = false;
-        let keys: BTreeSet<&String> = a.keys().chain(b.keys()).collect();
-        if keys.is_empty() {
-            return false;
-        }
-        for key in keys {
-            // A missing objective is malformed and ranks as invalid (NaN), not
-            // as a silently omitted dimension.
-            let va = a.get(key).copied().unwrap_or(f64::NAN);
-            let vb = b.get(key).copied().unwrap_or(f64::NAN);
+        let mut saw_objective = false;
+        let mut a_entries = a.iter().peekable();
+        let mut b_entries = b.iter().peekable();
+        loop {
+            let (va, vb) = match (a_entries.peek(), b_entries.peek()) {
+                (Some((a_key, a_value)), Some((b_key, b_value))) => match a_key.cmp(b_key) {
+                    Ordering::Less => {
+                        let value = **a_value;
+                        a_entries.next();
+                        (value, f64::NAN)
+                    }
+                    Ordering::Equal => {
+                        let values = (**a_value, **b_value);
+                        a_entries.next();
+                        b_entries.next();
+                        values
+                    }
+                    Ordering::Greater => {
+                        let value = **b_value;
+                        b_entries.next();
+                        (f64::NAN, value)
+                    }
+                },
+                (Some((_, a_value)), None) => {
+                    let value = **a_value;
+                    a_entries.next();
+                    (value, f64::NAN)
+                }
+                (None, Some((_, b_value))) => {
+                    let value = **b_value;
+                    b_entries.next();
+                    (f64::NAN, value)
+                }
+                (None, None) => break,
+            };
+            saw_objective = true;
+
             // Deterministic NaN policy: NaN is strictly worst. Handle the cases
             // involving NaN explicitly because `>` / `<` are always false for
             // NaN and would otherwise be silently treated as a tie.
@@ -867,13 +1005,7 @@ impl<D: Clone> Leaderboard<D, BTreeMap<String, f64>> {
                 dominated_some = true;
             }
         }
-        // Check if b has keys that a doesn't (a would have infinity there)
-        for key in b.keys() {
-            if !a.contains_key(key) {
-                return false; // a is worse (infinity) in this objective
-            }
-        }
-        dominated_some
+        saw_objective && dominated_some
     }
 
     /// Return 0-indexed front membership for a rectangular, finite two-objective
@@ -1276,21 +1408,42 @@ impl<D: Clone> Leaderboard<D, BTreeMap<String, f64>> {
         }
 
         let n = feasible.len();
+        let dense = dense_objective_matrix(&feasible);
 
         let mut domination_count: Vec<usize> = vec![0; n];
         let mut dominated_by: Vec<Vec<usize>> = vec![Vec::new(); n];
 
         for i in 0..n {
             for j in (i + 1)..n {
-                let obs_i = &feasible[i].observation;
-                let obs_j = &feasible[j].observation;
+                let relation = if let Some((objectives, values)) = &dense {
+                    let i_start = i * objectives;
+                    let j_start = j * objectives;
+                    dense_dominance_relation(
+                        &values[i_start..i_start + objectives],
+                        &values[j_start..j_start + objectives],
+                    )
+                } else {
+                    let obs_i = &feasible[i].observation;
+                    let obs_j = &feasible[j].observation;
+                    if Self::dominates(obs_i, obs_j) {
+                        Ordering::Less
+                    } else if Self::dominates(obs_j, obs_i) {
+                        Ordering::Greater
+                    } else {
+                        Ordering::Equal
+                    }
+                };
 
-                if Self::dominates(obs_i, obs_j) {
-                    dominated_by[i].push(j);
-                    domination_count[j] += 1;
-                } else if Self::dominates(obs_j, obs_i) {
-                    dominated_by[j].push(i);
-                    domination_count[i] += 1;
+                match relation {
+                    Ordering::Less => {
+                        dominated_by[i].push(j);
+                        domination_count[j] += 1;
+                    }
+                    Ordering::Greater => {
+                        dominated_by[j].push(i);
+                        domination_count[i] += 1;
+                    }
+                    Ordering::Equal => {}
                 }
             }
         }
@@ -1507,6 +1660,36 @@ impl<D: Clone> Leaderboard<D, BTreeMap<String, f64>> {
         }
 
         selected
+    }
+
+    /// Select top-k feasible trials with NSGA-II from a deterministic,
+    /// stratified sample of the retained feasible history.
+    ///
+    /// Feasible histories no larger than `max_candidates` use the exact global
+    /// [`Self::select_nsga2`] order. Larger feasible histories contribute one
+    /// midpoint from each equal-sized chronological stratum, bounding repeated
+    /// ranking work without favoring the newest trials. Infeasible trials do
+    /// not consume the candidate budget.
+    pub fn select_nsga2_stratified(&self, k: usize, max_candidates: usize) -> Vec<RankedTrial<D>> {
+        if self.trials.is_empty() || k == 0 || max_candidates == 0 {
+            return Vec::new();
+        }
+
+        let feasible_history: Vec<&Trial<D, BTreeMap<String, f64>>> = self
+            .trials
+            .iter()
+            .filter(|trial| Self::trial_is_feasible(trial))
+            .collect();
+
+        if feasible_history.len() <= max_candidates {
+            return self.select_nsga2(k);
+        }
+
+        let mut covered = Leaderboard::with_capacity(max_candidates);
+        for index in stratified_history_indices(feasible_history.len(), max_candidates) {
+            covered.push_existing_trial(feasible_history[index].clone());
+        }
+        covered.select_nsga2(k)
     }
 
     /// Select top-k trials using NSGA-II criteria, including infeasible.
@@ -1727,17 +1910,59 @@ mod tests {
     }
 
     #[test]
-    fn test_top_k_recent_limits_selection_to_bounded_window() {
+    fn test_top_k_stratified_covers_full_history_without_recency_bias() {
         let mut lb: Leaderboard<&str, f64> = Leaderboard::new();
 
-        lb.push("old_global_best", 0.0);
-        lb.push("recent_worst", 5.0);
-        lb.push("recent_best", 2.0);
+        // Six entries split into three two-entry strata select indices 1, 3,
+        // and 5. The global best is deliberately older than the newest three.
+        lb.push("old-padding", 9.0);
+        lb.push("old-global-best", 0.0);
+        lb.push("middle-padding", 8.0);
+        lb.push("middle", 4.0);
+        lb.push("recent-padding", 7.0);
+        lb.push("recent", 2.0);
+
+        let top = lb.top_k_stratified(1, 3);
+        assert_eq!(top.len(), 1);
+        assert_eq!(top[0].candidate, "old-global-best");
+        assert!(lb.top_k_stratified(1, 0).is_empty());
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_top_k_recent_preserves_legacy_newest_window() {
+        let mut lb: Leaderboard<&str, f64> = Leaderboard::new();
+
+        lb.push("old-global-best", 0.0);
+        lb.push("recent-worst", 5.0);
+        lb.push("recent-best", 2.0);
 
         let top = lb.top_k_recent(1, 2);
         assert_eq!(top.len(), 1);
-        assert_eq!(top[0].candidate, "recent_best");
+        assert_eq!(top[0].candidate, "recent-best");
         assert!(lb.top_k_recent(1, 0).is_empty());
+    }
+
+    #[test]
+    fn test_top_k_stratified_does_not_spend_capacity_on_infeasible_trials() {
+        let mut lb: Leaderboard<&str, f64> = Leaderboard::new();
+
+        // Sampling the six raw entries with a budget of three would select
+        // indices 1, 3, and 5, all of which are infeasible. Feasible-history
+        // stratification instead retains all three usable trials.
+        lb.push("feasible-old", 3.0);
+        lb.push("infeasible-old", f64::INFINITY);
+        lb.push("feasible-middle", 2.0);
+        lb.push("infeasible-middle", f64::NAN);
+        lb.push("feasible-recent", 1.0);
+        lb.push("infeasible-recent", f64::NEG_INFINITY);
+
+        let top = lb.top_k_stratified(3, 3);
+        assert_eq!(top.len(), 3);
+        assert_eq!(
+            top.iter().map(|trial| trial.candidate).collect::<Vec<_>>(),
+            ["feasible-recent", "feasible-middle", "feasible-old"]
+        );
     }
 
     #[test]
@@ -2171,6 +2396,56 @@ mod tests {
         // Both extremes should be selected (they have infinite crowding distance)
         assert!(candidates.contains(&"extreme1"));
         assert!(candidates.contains(&"extreme2"));
+    }
+
+    #[test]
+    fn test_select_nsga2_stratified_covers_full_history_without_recency_bias() {
+        let mut lb: Leaderboard<&str, BTreeMap<String, f64>> = Leaderboard::new();
+
+        let observation = |x, y| [("x".into(), x), ("y".into(), y)].into();
+        lb.push("old-padding", observation(9.0, 9.0));
+        lb.push("old-global-best", observation(0.0, 0.0));
+        lb.push("middle-padding", observation(8.0, 8.0));
+        lb.push("middle", observation(4.0, 4.0));
+        lb.push("recent-padding", observation(7.0, 7.0));
+        lb.push("recent", observation(2.0, 2.0));
+
+        let selected = lb.select_nsga2_stratified(1, 3);
+        let candidates: Vec<&str> = selected
+            .iter()
+            .map(|ranked| ranked.trial.candidate)
+            .collect();
+        assert_eq!(candidates, vec!["old-global-best"]);
+        assert!(lb.select_nsga2_stratified(1, 0).is_empty());
+    }
+
+    #[test]
+    fn test_select_nsga2_stratified_does_not_spend_capacity_on_infeasible_trials() {
+        let mut lb: Leaderboard<&str, BTreeMap<String, f64>> = Leaderboard::new();
+
+        let observation = |x, y| [("x".into(), x), ("y".into(), y)].into();
+        lb.push("feasible-old", observation(3.0, 1.0));
+        lb.push("infeasible-old", observation(f64::INFINITY, 0.0));
+        lb.push("feasible-middle", observation(2.0, 2.0));
+        lb.push("infeasible-middle", observation(0.0, f64::NAN));
+        lb.push("feasible-recent", observation(1.0, 3.0));
+        lb.push("infeasible-recent", observation(f64::NEG_INFINITY, 0.0));
+
+        let selected = lb.select_nsga2_stratified(3, 3);
+        assert_eq!(selected.len(), 3);
+        assert!(
+            selected
+                .iter()
+                .all(|ranked| ranked.trial.candidate.starts_with("feasible-"))
+        );
+    }
+
+    #[test]
+    fn test_stratified_history_indices_are_deterministic_and_global() {
+        assert_eq!(stratified_history_indices(0, 4), Vec::<usize>::new());
+        assert_eq!(stratified_history_indices(4, 0), Vec::<usize>::new());
+        assert_eq!(stratified_history_indices(4, 4), vec![0, 1, 2, 3]);
+        assert_eq!(stratified_history_indices(10, 4), vec![1, 4, 7, 9]);
     }
 
     #[test]

--- a/opt_engine/src/strategies/gmm.rs
+++ b/opt_engine/src/strategies/gmm.rs
@@ -12,7 +12,10 @@
 //! Gaussian Mixture Model (GMM) strategy for informed sampling.
 //!
 //! This strategy samples from a user-specified GMM in the standardized [0, 1]^n
-//! hypercube. Samples are clipped to the unit hypercube (censored GMM).
+//! hypercube. Strategy suggestions use Owen-scrambled Gauss-Sobol' points:
+//! Sobol' coordinates select the mixture component and are transformed through
+//! the inverse standard-normal CDF before applying the component Cholesky
+//! factor. Samples are clipped to the unit hypercube (censored GMM).
 //!
 //! The GMM can be specified directly with parameters, or fitted from observed
 //! normalized samples using the EM algorithm.
@@ -46,6 +49,101 @@ use std::sync::{Arc, Mutex, RwLock};
 
 const WEIGHT_SUM_TOLERANCE: f64 = 1e-9;
 const COVARIANCE_SYMMETRY_TOLERANCE: f64 = 1e-12;
+/// `sobol_burley` supports 256 dimensions and 2^16 points per scrambled
+/// sequence. Logical dimensions and later samples are assigned deterministic
+/// independently scrambled blocks so GMM sampling remains quasi-random and
+/// non-panicking beyond either native limit.
+const SOBOL_BLOCK_DIMS: usize = 256;
+const SOBOL_BLOCK_SAMPLES: u64 = 1 << 16;
+/// `sobol_burley` emits one of 2^23 values in `[0, 1)`. Moving each value to
+/// the center of its represented cell keeps the inverse-normal input strictly
+/// inside `(0, 1)` without clipping an entire tail to one value.
+const SOBOL_F32_HALF_CELL: f64 = 1.0 / ((1u64 << 24) as f64);
+
+/// SplitMix64 finalizer used only to derive independent deterministic Sobol'
+/// scrambling seeds from the public 64-bit strategy seed and block numbers.
+#[inline]
+fn mix_u64(mut value: u64) -> u64 {
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+/// Return a deterministic Owen-scrambled Sobol' coordinate in the open unit
+/// interval. Native Sobol' blocks are extended by independently scrambling
+/// each 2^16-sample and 256-dimensional block.
+#[inline]
+fn gauss_sobol_uniform(sample_index: u64, logical_dimension: usize, seed: u64) -> f64 {
+    let sample_block = sample_index / SOBOL_BLOCK_SAMPLES;
+    let native_sample = (sample_index % SOBOL_BLOCK_SAMPLES) as u32;
+    let dimension_block = logical_dimension / SOBOL_BLOCK_DIMS;
+    let native_dimension = (logical_dimension % SOBOL_BLOCK_DIMS) as u32;
+    let block_key = seed
+        ^ sample_block.wrapping_mul(0x9e37_79b9_7f4a_7c15)
+        ^ (dimension_block as u64).wrapping_mul(0xd1b5_4a32_d192_ed03);
+    let mixed = mix_u64(block_key);
+    let scramble_seed = (mixed ^ (mixed >> 32)) as u32;
+    f64::from(sobol_burley::sample(
+        native_sample,
+        native_dimension,
+        scramble_seed,
+    )) + SOBOL_F32_HALF_CELL
+}
+
+/// Inverse CDF of a standard normal distribution.
+///
+/// This is Acklam's rational approximation. Its relative error is below about
+/// 1.2e-9 over `(0, 1)`, substantially finer than the f32 Sobol' coordinates
+/// supplied by `sobol_burley`.
+fn standard_normal_inverse_cdf(probability: f64) -> f64 {
+    debug_assert!(probability > 0.0 && probability < 1.0);
+
+    const A: [f64; 6] = [
+        -3.969_683_028_665_376e1,
+        2.209_460_984_245_205e2,
+        -2.759_285_104_469_687e2,
+        1.383_577_518_672_69e2,
+        -3.066_479_806_614_716e1,
+        2.506_628_277_459_239,
+    ];
+    const B: [f64; 5] = [
+        -5.447_609_879_822_406e1,
+        1.615_858_368_580_409e2,
+        -1.556_989_798_598_866e2,
+        6.680_131_188_771_972e1,
+        -1.328_068_155_288_572e1,
+    ];
+    const C: [f64; 6] = [
+        -7.784_894_002_430_293e-3,
+        -3.223_964_580_411_365e-1,
+        -2.400_758_277_161_838,
+        -2.549_732_539_343_734,
+        4.374_664_141_464_968,
+        2.938_163_982_698_783,
+    ];
+    const D: [f64; 4] = [
+        7.784_695_709_041_462e-3,
+        3.224_671_290_700_398e-1,
+        2.445_134_137_142_996,
+        3.754_408_661_907_416,
+    ];
+    const LOWER_TAIL: f64 = 0.024_25;
+
+    if probability < LOWER_TAIL {
+        let q = (-2.0 * probability.ln()).sqrt();
+        (((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
+            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
+    } else if probability > 1.0 - LOWER_TAIL {
+        let q = (-2.0 * (1.0 - probability).ln()).sqrt();
+        -(((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
+            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
+    } else {
+        let q = probability - 0.5;
+        let r = q * q;
+        (((((A[0] * r + A[1]) * r + A[2]) * r + A[3]) * r + A[4]) * r + A[5]) * q
+            / (((((B[0] * r + B[1]) * r + B[2]) * r + B[3]) * r + B[4]) * r + 1.0)
+    }
+}
 
 /// Validation or numerical error produced by GMM construction and fitting.
 #[derive(Clone, Debug, PartialEq)]
@@ -449,6 +547,44 @@ impl GaussianComponent {
         }
     }
 
+    /// Fill a caller-owned buffer from one Gauss-Sobol' point.
+    ///
+    /// `normal_dimension_offset` reserves preceding Sobol' coordinates for
+    /// mixture-component selection, so each Gaussian coordinate uses a distinct
+    /// dimension of the same low-discrepancy point.
+    fn sample_gauss_sobol_into(
+        &self,
+        sample_index: u64,
+        seed: u64,
+        normal_dimension_offset: usize,
+        sample: &mut Vec<f64>,
+    ) -> Result<(), GmmError> {
+        let dim = self.dim();
+        sample.resize(dim, 0.0);
+        for (dimension, value) in sample.iter_mut().enumerate() {
+            let uniform = gauss_sobol_uniform(
+                sample_index,
+                normal_dimension_offset.saturating_add(dimension),
+                seed,
+            );
+            *value = standard_normal_inverse_cdf(uniform);
+        }
+        for row in (0..dim).rev() {
+            let mut value = self.mean[row];
+            for (column, standard_normal) in sample.iter().copied().take(row + 1).enumerate() {
+                value += self.cholesky_l[(row, column)] * standard_normal;
+            }
+            sample[row] = value;
+        }
+        if sample.iter().all(|value| value.is_finite()) {
+            Ok(())
+        } else {
+            Err(GmmError::NumericalFailure(
+                "Gauss-Sobol sample contains a non-finite value",
+            ))
+        }
+    }
+
     pub fn dim(&self) -> usize {
         self.mean.len()
     }
@@ -668,6 +804,34 @@ impl GmmParams {
     ) -> Result<(), GmmError> {
         let idx = self.component_distribution.sample(rng);
         self.components[idx].sample_into(rng, sample)?;
+        for value in sample {
+            *value = value.clamp(0.0, 1.0);
+        }
+        Ok(())
+    }
+
+    /// Fill a caller-owned buffer with a clamped Gauss-Sobol' GMM sample.
+    ///
+    /// The first Sobol' coordinate selects a component by inverse transform;
+    /// the remaining coordinates become independent standard-normal quantiles.
+    fn sample_gauss_sobol_clamped_into(
+        &self,
+        sample_index: u64,
+        seed: u64,
+        sample: &mut Vec<f64>,
+    ) -> Result<(), GmmError> {
+        let component_quantile = gauss_sobol_uniform(sample_index, 0, seed);
+        let mut cumulative_weight = 0.0;
+        let mut component_index = self.components.len() - 1;
+        for (index, weight) in self.weights.iter().copied().enumerate() {
+            cumulative_weight += weight;
+            if component_quantile < cumulative_weight {
+                component_index = index;
+                break;
+            }
+        }
+
+        self.components[component_index].sample_gauss_sobol_into(sample_index, seed, 1, sample)?;
         for value in sample {
             *value = value.clamp(0.0, 1.0);
         }
@@ -1035,8 +1199,10 @@ fn kmeans_pp_init(
 
 /// A GMM-based sampling strategy.
 ///
-/// Samples from a Gaussian Mixture Model in the unit hypercube [0, 1]^n.
-/// Points are clipped to the hypercube bounds (censored GMM).
+/// Samples from a Gaussian Mixture Model in the unit hypercube [0, 1]^n using
+/// a seeded Owen-scrambled Gauss-Sobol' sequence. The seed and sequence cursor
+/// are serialized, so checkpoints resume at the exact next point. Points are
+/// clipped to the hypercube bounds (censored GMM).
 ///
 /// # Example
 ///
@@ -1232,10 +1398,6 @@ where
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let call_index = self.counter.fetch_add(1, Ordering::Relaxed);
-        let call_seed = self
-            .seed
-            .wrapping_add(call_index.wrapping_mul(6364136223846793005));
-        let mut rng = SmallRng::seed_from_u64(call_seed);
         let mut sample = self
             .sample_scratch
             .lock()
@@ -1247,7 +1409,9 @@ where
         // so this hot path, which runs under the engine write lock inside axum/
         // PyO3 handlers, never panics.
         if params.dim() == dim {
-            if let Err(error) = params.sample_clamped_into(&mut rng, &mut sample) {
+            if let Err(error) =
+                params.sample_gauss_sobol_clamped_into(call_index, self.seed, &mut sample)
+            {
                 eprintln!(
                     "GmmStrategy::suggest: sampling failed ({error}), falling back to cube center"
                 );
@@ -1500,6 +1664,37 @@ mod tests {
     use crate::traits::SampleSpace;
 
     #[test]
+    fn test_standard_normal_inverse_cdf_known_quantiles() {
+        let quantiles = [
+            (0.001, -3.090_232_306_167_813),
+            (0.025, -1.959_963_984_540_054),
+            (0.5, 0.0),
+            (0.975, 1.959_963_984_540_054),
+            (0.999, 3.090_232_306_167_813),
+        ];
+        for (probability, expected) in quantiles {
+            let actual = standard_normal_inverse_cdf(probability);
+            assert!(
+                (actual - expected).abs() < 5e-9,
+                "Phi^-1({probability}) = {actual}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_gauss_sobol_uniform_extends_native_limits() {
+        for sample_index in [0, SOBOL_BLOCK_SAMPLES - 1, SOBOL_BLOCK_SAMPLES, u64::MAX] {
+            for dimension in [0, SOBOL_BLOCK_DIMS - 1, SOBOL_BLOCK_DIMS, 10_000] {
+                let value = gauss_sobol_uniform(sample_index, dimension, 42);
+                assert!(
+                    value > 0.0 && value < 1.0,
+                    "sample {sample_index}, dimension {dimension} produced {value}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_gaussian_component_sampling() {
         let mean = DVector::from_vec(vec![0.5, 0.5]);
         let comp = GaussianComponent::isotropic(mean.clone(), 0.01).unwrap();
@@ -1562,6 +1757,43 @@ mod tests {
             let point = strategy.suggest(&space);
             assert!(space.contains(&point));
         }
+    }
+
+    #[test]
+    fn test_gmm_strategy_gauss_sobol_stratifies_mixture_weights() {
+        use crate::scales::LinearScale;
+        use crate::spaces::ContinuousSpace;
+
+        let first = GaussianComponent::isotropic(DVector::from_vec(vec![0.25]), 1e-8).unwrap();
+        let second = GaussianComponent::isotropic(DVector::from_vec(vec![0.75]), 1e-8).unwrap();
+        let params = GmmParams::new(vec![0.25, 0.75], vec![first, second]).unwrap();
+        let strategy = GmmStrategy::<ContinuousSpace<LinearScale>>::new(42, params);
+        let space = ContinuousSpace::new(0.0, 1.0);
+
+        let first_component_count = (0..256).filter(|_| strategy.suggest(&space) < 0.5).count();
+        assert_eq!(
+            first_component_count, 64,
+            "a 256-point Sobol' block should allocate exactly 25% of points to the first component"
+        );
+    }
+
+    #[test]
+    fn test_gmm_strategy_gauss_sobol_preserves_categorical_mapping() {
+        use crate::spaces::CategoricalSpace;
+
+        let space = CategoricalSpace::from_strs(&["adam", "sgd", "rmsprop"]);
+        let strategy = GmmStrategy::<CategoricalSpace>::uniform_prior(42, 1, 0.25).unwrap();
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..256 {
+            let candidate = strategy.suggest(&space);
+            assert!(space.contains(&candidate));
+            seen.insert(candidate);
+        }
+        assert_eq!(
+            seen.len(),
+            3,
+            "all categorical bins should remain reachable"
+        );
     }
 
     #[test]
@@ -2382,9 +2614,18 @@ mod tests {
 
         let params = GmmParams::uniform_prior(4, 0.1).unwrap();
         let mut rng = SmallRng::seed_from_u64(11);
-        let sampling_start = Instant::now();
+        let random_sampling_start = Instant::now();
         for _ in 0..100_000 {
             params.sample_clamped(&mut rng).unwrap();
+        }
+        let random_sampling_elapsed = random_sampling_start.elapsed();
+
+        let mut sample = Vec::with_capacity(4);
+        let sampling_start = Instant::now();
+        for sample_index in 0..100_000 {
+            params
+                .sample_gauss_sobol_clamped_into(sample_index, 11, &mut sample)
+                .unwrap();
         }
         let sampling_elapsed = sampling_start.elapsed();
 
@@ -2399,7 +2640,7 @@ mod tests {
         let fitting_elapsed = fitting_start.elapsed();
 
         eprintln!(
-            "100k cached-distribution suggestions: {sampling_elapsed:?}; 2k-sample fit: {fitting_elapsed:?}"
+            "100k pseudorandom suggestions: {random_sampling_elapsed:?}; 100k Gauss-Sobol' suggestions: {sampling_elapsed:?}; 2k-sample fit: {fitting_elapsed:?}"
         );
         let budget = Duration::from_secs(5);
         assert!(


### PR DESCRIPTION
## Summary

- select multi-group GMM elites by NSGA-II non-domination rank and crowding distance instead of a summed scalar proxy
- sample GMM exploitation candidates with a seeded Owen-scrambled Gauss--Sobol' sequence, including deterministic blocks beyond the backend's native dimension and sample limits
- bound refit work with configurable sample/candidate limits and deterministic full-history stratification
- avoid repeated multi-objective ranking during local batch completion while preserving eager public `tell()` behavior, retry receipts, and checkpoint replay
- align TLP/grouping documentation, bindings, examples, and `Unreleased` notes with the implemented semantics

## Why

The documented method treats explicit priority groups as Pareto axes and uses priority only to scalarize objectives within a group. The fitted GMM should therefore learn from Pareto-rank/crowding elites, not from a sum across groups. The paper method also specifies Gauss--Sobol' mixture sampling. Repeated full ranking during local batches made the correct multi-group path unnecessarily expensive.

## Compatibility

- Existing YAML, JSON, and checkpoint configurations remain compatible; omitted refit limits deserialize to 4096 samples and 16384 candidates.
- Direct Rust `StrategyConfig { ... }` literals must provide the two new public fields. This is a source-level change to the current release-candidate API and is called out here for review.
- The historical public `Leaderboard::top_k_recent` API remains available with its original newest-window behavior and is deprecated in favor of `top_k_stratified`.
- The 4096/16384 values are configurable implementation safeguards, not requirements of the abstract method.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-features --all-targets -- -D warnings`
- `cargo test --locked --workspace --all-features`
- all six ignored scalability/quality probes, including the new multi-objective selection and deferred-batch probes
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --all-features --no-deps`
- `python3 .github/scripts/verify_package_contents.py cargo`
- `uv run --directory hola-py maturin develop`
- `uv run --directory hola-py ruff check .`
- `uv run --directory hola-py ruff format --check .`
- `uv run --directory hola-py ty check .`
- `uv run --directory hola-py pytest tests/ -q` (`412 passed, 4 skipped`)

The benchmark harness and its authenticated exact-budget protocol are intentionally split into a dependent follow-up PR.
