### PR TITLE
Compose benchmark reports with method-level provenance

### DIFF
--- a/hola-py/benchmarks/__main__.py
+++ b/hola-py/benchmarks/__main__.py
@@ -24,14 +24,25 @@ def main() -> None:
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    subparsers.add_parser("run-single", help="Run single-objective benchmarks")
-    subparsers.add_parser("run-multi", help="Run multi-objective benchmarks")
-    subparsers.add_parser("run-hpo", help="Run the practical mixed-space HPO benchmark")
-    subparsers.add_parser("run-grouped-tlp", help="Run the grouped-TLP capability benchmark")
-    subparsers.add_parser("plot-single", help="Generate single-objective plots")
-    subparsers.add_parser("plot-multi", help="Generate multi-objective plots")
-    subparsers.add_parser("plot-hpo", help="Report the practical HPO campaign")
-    subparsers.add_parser("plot-grouped-tlp", help="Report the grouped-TLP campaign")
+    subparsers.add_parser("run-single", help="Run single-objective benchmarks", add_help=False)
+    subparsers.add_parser("run-multi", help="Run multi-objective benchmarks", add_help=False)
+    subparsers.add_parser(
+        "run-hpo", help="Run the practical mixed-space HPO benchmark", add_help=False
+    )
+    subparsers.add_parser(
+        "run-grouped-tlp", help="Run the grouped-TLP capability benchmark", add_help=False
+    )
+    subparsers.add_parser("plot-single", help="Generate single-objective plots", add_help=False)
+    subparsers.add_parser("plot-multi", help="Generate multi-objective plots", add_help=False)
+    subparsers.add_parser("plot-hpo", help="Report the practical HPO campaign", add_help=False)
+    subparsers.add_parser(
+        "plot-grouped-tlp", help="Report the grouped-TLP campaign", add_help=False
+    )
+    subparsers.add_parser(
+        "compose-results",
+        help="Compose compatible campaigns for authenticated reporting",
+        add_help=False,
+    )
 
     args, remaining = parser.parse_known_args()
 
@@ -70,6 +81,10 @@ def main() -> None:
         from benchmarks.plotting.grouped_tlp import main as plot_grouped_tlp
 
         plot_grouped_tlp()
+    elif args.command == "compose-results":
+        from benchmarks.data.composite import main as compose_results
+
+        compose_results()
 
 
 if __name__ == "__main__":

--- a/hola-py/benchmarks/data/composite.py
+++ b/hola-py/benchmarks/data/composite.py
@@ -1,0 +1,538 @@
+# Copyright 2026 BlackRock, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Authenticated report composition across compatible benchmark campaigns."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Sequence
+from itertools import product
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from benchmarks.data.manifest import (
+    MANIFEST_FILENAME,
+    attach_fingerprint,
+    manifest_fingerprint,
+)
+from benchmarks.data.persistence import ResultStore
+
+COMPOSITE_MANIFEST_FILENAME = "composite_manifest.json"
+COMPOSITE_VERSION = "1"
+
+SOURCE_PATH_COLUMN = "source_campaign_path"
+SOURCE_MANIFEST_COLUMN = "source_campaign_fingerprint"
+SOURCE_RESULTS_COLUMN = "source_results_sha256"
+
+_RESULT_FILENAMES = {
+    "single_objective": "single_objective.csv",
+    "multi_objective": "multi_objective.csv",
+    "hpo": "hpo.csv",
+}
+_CONTRACT_FIELDS = {
+    "protocol_version",
+    "run_kind",
+    "problems",
+    "budgets",
+    "n_runs",
+    "campaign_configuration",
+}
+_SOURCE_FIELDS = {"path", "campaign_fingerprint", "result_file", "optimizers"}
+_RESULT_FILE_FIELDS = {"filename", "byte_size", "sha256"}
+
+
+def _is_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _string_axis(value: Any, label: str) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, str) or not item for item in value)
+        or len(value) != len(set(value))
+    ):
+        raise RuntimeError(f"{label} must be a nonempty list of unique strings")
+    return value
+
+
+def _integer_axis(value: Any, label: str) -> list[int]:
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(isinstance(item, bool) or not isinstance(item, int) or item <= 0 for item in value)
+        or len(value) != len(set(value))
+    ):
+        raise RuntimeError(f"{label} must be a nonempty list of unique positive integers")
+    return value
+
+
+def _campaign_contract(manifest: dict[str, Any]) -> dict[str, Any]:
+    protocol_version = manifest.get("protocol_version")
+    run_kind = manifest.get("run_kind")
+    if not isinstance(protocol_version, str) or not protocol_version:
+        raise RuntimeError("campaign protocol_version must be a nonempty string")
+    if run_kind not in _RESULT_FILENAMES:
+        raise RuntimeError(f"campaign has unsupported run kind {run_kind!r}")
+    problems = _string_axis(manifest.get("problems"), "campaign problems")
+    budgets = _integer_axis(manifest.get("budgets"), "campaign budgets")
+    n_runs = manifest.get("n_runs")
+    if isinstance(n_runs, bool) or not isinstance(n_runs, int) or n_runs <= 0:
+        raise RuntimeError("campaign n_runs must be a positive integer")
+    campaign_configuration = manifest.get("campaign_configuration")
+    if campaign_configuration is not None and not isinstance(campaign_configuration, dict):
+        raise RuntimeError("campaign_configuration must be an object when present")
+    return {
+        "protocol_version": protocol_version,
+        "run_kind": run_kind,
+        "problems": list(problems),
+        "budgets": list(budgets),
+        "n_runs": n_runs,
+        "campaign_configuration": campaign_configuration,
+    }
+
+
+def _read_json_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"cannot read {label}: {error}") from error
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{label} must contain a JSON object")
+    return value
+
+
+def _source_store(source_dir: Path) -> ResultStore:
+    if not source_dir.is_dir():
+        raise RuntimeError(f"composite source campaign directory is missing: {source_dir}")
+    if (source_dir / COMPOSITE_MANIFEST_FILENAME).exists():
+        raise RuntimeError("a composite source must be an ordinary benchmark campaign")
+    return ResultStore(source_dir)
+
+
+def _artifact_identity(path: Path) -> dict[str, Any]:
+    digest = hashlib.sha256()
+    byte_size = 0
+    try:
+        with path.open("rb") as result_file:
+            while chunk := result_file.read(1024 * 1024):
+                digest.update(chunk)
+                byte_size += len(chunk)
+    except OSError as error:
+        raise RuntimeError(f"cannot read benchmark result artifact {path}: {error}") from error
+    return {
+        "filename": path.name,
+        "byte_size": byte_size,
+        "sha256": digest.hexdigest(),
+    }
+
+
+def _source_entry(
+    composite_dir: Path,
+    source_dir: Path,
+    source_manifest: dict[str, Any],
+    optimizers: list[str],
+    run_kind: str,
+) -> dict[str, Any]:
+    result_path = source_dir / _RESULT_FILENAMES[run_kind]
+    if not result_path.is_file():
+        raise RuntimeError(f"source campaign result artifact is missing: {result_path}")
+    relative_path = Path(os.path.relpath(source_dir, start=composite_dir)).as_posix()
+    return {
+        "path": relative_path,
+        "campaign_fingerprint": source_manifest["fingerprint"],
+        "result_file": _artifact_identity(result_path),
+        "optimizers": optimizers,
+    }
+
+
+def validate_composite_manifest(manifest: dict[str, Any]) -> None:
+    """Reject malformed, altered, ambiguous, or incomplete compositions."""
+    expected_fingerprint = manifest_fingerprint(manifest)
+    if manifest.get("fingerprint") != expected_fingerprint:
+        raise RuntimeError("composite manifest fingerprint is missing or invalid")
+    expected_fields = {
+        "composite_version",
+        "contract",
+        "optimizers",
+        "sources",
+        "fingerprint",
+    }
+    if set(manifest) != expected_fields:
+        raise RuntimeError("composite manifest has unexpected or missing fields")
+    if manifest["composite_version"] != COMPOSITE_VERSION:
+        raise RuntimeError(
+            f"unsupported composite manifest version {manifest['composite_version']!r}"
+        )
+
+    contract = manifest["contract"]
+    if not isinstance(contract, dict) or set(contract) != _CONTRACT_FIELDS:
+        raise RuntimeError("composite manifest has a malformed campaign contract")
+    if not isinstance(contract["protocol_version"], str) or not contract["protocol_version"]:
+        raise RuntimeError("composite protocol_version must be a nonempty string")
+    run_kind = contract["run_kind"]
+    if run_kind not in _RESULT_FILENAMES:
+        raise RuntimeError(f"composite manifest has unsupported run kind {run_kind!r}")
+    _string_axis(contract["problems"], "composite problems")
+    _integer_axis(contract["budgets"], "composite budgets")
+    n_runs = contract["n_runs"]
+    if isinstance(n_runs, bool) or not isinstance(n_runs, int) or n_runs <= 0:
+        raise RuntimeError("composite n_runs must be a positive integer")
+    if contract["campaign_configuration"] is not None and not isinstance(
+        contract["campaign_configuration"], dict
+    ):
+        raise RuntimeError("composite campaign_configuration must be an object or null")
+
+    target_optimizers = _string_axis(manifest["optimizers"], "composite optimizers")
+    sources = manifest["sources"]
+    if not isinstance(sources, list) or not sources:
+        raise RuntimeError("composite sources must be a nonempty list")
+
+    assigned: set[str] = set()
+    source_paths: set[str] = set()
+    expected_filename = _RESULT_FILENAMES[run_kind]
+    for source in sources:
+        if not isinstance(source, dict) or set(source) != _SOURCE_FIELDS:
+            raise RuntimeError("composite manifest has a malformed source")
+        source_path = source["path"]
+        if (
+            not isinstance(source_path, str)
+            or not source_path
+            or source_path == "."
+            or Path(source_path).is_absolute()
+            or "\\" in source_path
+        ):
+            raise RuntimeError("composite source paths must be relative POSIX directory paths")
+        if source_path in source_paths:
+            raise RuntimeError(f"composite source path is repeated: {source_path}")
+        source_paths.add(source_path)
+        if not _is_sha256(source["campaign_fingerprint"]):
+            raise RuntimeError("composite source has an invalid campaign fingerprint")
+
+        artifact = source["result_file"]
+        if not isinstance(artifact, dict) or set(artifact) != _RESULT_FILE_FIELDS:
+            raise RuntimeError("composite source has a malformed result-file identity")
+        if artifact["filename"] != expected_filename:
+            raise RuntimeError(f"composite source result filename must be {expected_filename!r}")
+        byte_size = artifact["byte_size"]
+        if isinstance(byte_size, bool) or not isinstance(byte_size, int) or byte_size < 0:
+            raise RuntimeError("composite source result byte_size must be nonnegative")
+        if not _is_sha256(artifact["sha256"]):
+            raise RuntimeError("composite source has an invalid result SHA-256")
+
+        selected = _string_axis(source["optimizers"], "composite source optimizers")
+        unknown = [optimizer for optimizer in selected if optimizer not in target_optimizers]
+        if unknown:
+            raise RuntimeError(
+                "composite source assigns optimizer(s) outside the target campaign: "
+                + ", ".join(unknown)
+            )
+        overlap = assigned.intersection(selected)
+        if overlap:
+            raise RuntimeError(
+                "composite optimizer assignments overlap: " + ", ".join(sorted(overlap))
+            )
+        assigned.update(selected)
+
+    missing = [optimizer for optimizer in target_optimizers if optimizer not in assigned]
+    if missing:
+        raise RuntimeError("composite optimizer assignments are incomplete: " + ", ".join(missing))
+
+
+def build_composite_manifest(
+    composite_dir: Path,
+    base_results_dir: Path,
+    replacements: Sequence[tuple[Path, Sequence[str]]],
+) -> dict[str, Any]:
+    """Describe a base campaign with method-level source replacements."""
+    composite_dir = composite_dir.resolve()
+    base_results_dir = base_results_dir.resolve()
+    base_store = _source_store(base_results_dir)
+    base_manifest = base_store.load_manifest()
+    contract = _campaign_contract(base_manifest)
+    target_optimizers = _string_axis(base_manifest.get("optimizers"), "base optimizers")
+
+    assignments = {optimizer: base_results_dir for optimizer in target_optimizers}
+    explicitly_replaced: set[str] = set()
+    for replacement_dir, replacement_optimizers in replacements:
+        selected = list(replacement_optimizers)
+        _string_axis(selected, "replacement optimizers")
+        unknown = [optimizer for optimizer in selected if optimizer not in target_optimizers]
+        if unknown:
+            raise RuntimeError(
+                "replacement optimizer(s) are absent from the base campaign: " + ", ".join(unknown)
+            )
+        overlap = explicitly_replaced.intersection(selected)
+        if overlap:
+            raise RuntimeError(
+                "optimizer replacement is assigned more than once: " + ", ".join(sorted(overlap))
+            )
+        source_dir = replacement_dir.resolve()
+        for optimizer in selected:
+            assignments[optimizer] = source_dir
+        explicitly_replaced.update(selected)
+
+    grouped: dict[Path, list[str]] = {}
+    for optimizer in target_optimizers:
+        grouped.setdefault(assignments[optimizer], []).append(optimizer)
+
+    sources = []
+    for source_dir, selected in grouped.items():
+        store = _source_store(source_dir)
+        source_manifest = store.load_manifest(expected_run_kind=contract["run_kind"])
+        source_contract = _campaign_contract(source_manifest)
+        if source_contract != contract:
+            changed = [
+                field
+                for field in sorted(_CONTRACT_FIELDS)
+                if source_contract[field] != contract[field]
+            ]
+            raise RuntimeError(
+                "source campaign is incompatible with the composite contract "
+                f"(changed fields: {', '.join(changed)})"
+            )
+        source_optimizers = _string_axis(
+            source_manifest.get("optimizers"), "source campaign optimizers"
+        )
+        missing = [optimizer for optimizer in selected if optimizer not in source_optimizers]
+        if missing:
+            raise RuntimeError(
+                "assigned optimizer(s) are absent from the source campaign: " + ", ".join(missing)
+            )
+        # A composite is a reporting artifact, so unlike an in-progress
+        # campaign it must be usable at creation time. Validate the selected
+        # projection before pinning the result-file digest.
+        store.load_complete_selected(contract["run_kind"], selected)
+        sources.append(
+            _source_entry(
+                composite_dir,
+                source_dir,
+                source_manifest,
+                selected,
+                contract["run_kind"],
+            )
+        )
+
+    manifest = attach_fingerprint(
+        {
+            "composite_version": COMPOSITE_VERSION,
+            "contract": contract,
+            "optimizers": list(target_optimizers),
+            "sources": sources,
+        }
+    )
+    validate_composite_manifest(manifest)
+    return manifest
+
+
+def write_composite_manifest(
+    output_dir: Path,
+    base_results_dir: Path,
+    replacements: Sequence[tuple[Path, Sequence[str]]],
+) -> dict[str, Any]:
+    """Atomically write a composite manifest into a fresh report directory."""
+    output_dir = output_dir.resolve()
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise RuntimeError(f"composite output directory must be empty: {output_dir}")
+    manifest = build_composite_manifest(output_dir, base_results_dir, replacements)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if any(output_dir.iterdir()):
+        raise RuntimeError(f"composite output directory must be empty: {output_dir}")
+    manifest_path = output_dir / COMPOSITE_MANIFEST_FILENAME
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        dir=output_dir,
+        prefix=f".{COMPOSITE_MANIFEST_FILENAME}.",
+        suffix=".tmp",
+        delete=False,
+    ) as file:
+        temporary = Path(file.name)
+        file.write(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+        file.flush()
+        os.fsync(file.fileno())
+    try:
+        os.link(temporary, manifest_path)
+    except FileExistsError as error:
+        raise RuntimeError(f"composite manifest already exists at {manifest_path}") from error
+    finally:
+        temporary.unlink(missing_ok=True)
+    return manifest
+
+
+def _load_ordinary_results(results_dir: Path, run_kind: str) -> pd.DataFrame:
+    store = ResultStore(results_dir)
+    if run_kind == "single_objective":
+        return store.load_complete_single()
+    if run_kind == "multi_objective":
+        return store.load_complete_multi()
+    if run_kind == "hpo":
+        return store.load_complete_hpo()
+    raise RuntimeError(f"unsupported benchmark run kind {run_kind!r}")
+
+
+def _verify_source(
+    composite_dir: Path,
+    source: dict[str, Any],
+    contract: dict[str, Any],
+) -> tuple[Path, dict[str, Any]]:
+    source_dir = (composite_dir / source["path"]).resolve()
+    store = _source_store(source_dir)
+    source_manifest = store.load_manifest(expected_run_kind=contract["run_kind"])
+    if source_manifest["fingerprint"] != source["campaign_fingerprint"]:
+        raise RuntimeError(
+            f"source campaign fingerprint changed for composite source {source['path']!r}"
+        )
+    if _campaign_contract(source_manifest) != contract:
+        raise RuntimeError(
+            f"source campaign contract changed for composite source {source['path']!r}"
+        )
+    source_optimizers = _string_axis(
+        source_manifest.get("optimizers"), "source campaign optimizers"
+    )
+    missing = [
+        optimizer for optimizer in source["optimizers"] if optimizer not in source_optimizers
+    ]
+    if missing:
+        raise RuntimeError(
+            f"composite source {source['path']!r} no longer declares optimizer(s): "
+            + ", ".join(missing)
+        )
+
+    result_path = source_dir / source["result_file"]["filename"]
+    observed_artifact = _artifact_identity(result_path)
+    if observed_artifact != source["result_file"]:
+        raise RuntimeError(
+            f"source result artifact changed for composite source {source['path']!r}"
+        )
+    return source_dir, source_manifest
+
+
+def _validate_composed_rows(results: pd.DataFrame, manifest: dict[str, Any]) -> None:
+    contract = manifest["contract"]
+    optimizers = manifest["optimizers"]
+    key_columns = ["problem", "optimizer", "budget", "run_id"]
+    duplicate_mask = results.duplicated(key_columns, keep=False)
+    if duplicate_mask.any():
+        raise RuntimeError("composite results contain overlapping run keys")
+    expected_keys = set(
+        product(
+            contract["problems"],
+            optimizers,
+            contract["budgets"],
+            range(contract["n_runs"]),
+        )
+    )
+    observed_keys = set(results[key_columns].itertuples(index=False, name=None))
+    if observed_keys != expected_keys:
+        missing = expected_keys - observed_keys
+        extra = observed_keys - expected_keys
+        raise RuntimeError(
+            "composite results do not cover the target Cartesian product "
+            f"(missing {len(missing)}, unexpected {len(extra)})"
+        )
+
+    seed_columns = ("search_seed", "split_seed") if contract["run_kind"] == "hpo" else ("seed",)
+    pairing_keys = ["problem", "budget", "run_id"]
+    for column in seed_columns:
+        paired_counts = results.groupby(pairing_keys, dropna=False)[column].nunique(dropna=False)
+        if (paired_counts != 1).any():
+            raise RuntimeError(f"composite results violate cross-optimizer {column} pairing")
+
+
+def load_composite_results(composite_dir: Path, expected_run_kind: str) -> pd.DataFrame:
+    """Load a validated virtual union without copying source result files."""
+    manifest_path = composite_dir / COMPOSITE_MANIFEST_FILENAME
+    manifest = _read_json_object(manifest_path, "composite manifest")
+    validate_composite_manifest(manifest)
+    contract = manifest["contract"]
+    if contract["run_kind"] != expected_run_kind:
+        raise RuntimeError(f"expected a {expected_run_kind} report, found {contract['run_kind']!r}")
+
+    frames: list[pd.DataFrame] = []
+    for source in manifest["sources"]:
+        source_dir, source_manifest = _verify_source(composite_dir, source, contract)
+        frame = ResultStore(source_dir).load_complete_selected(
+            expected_run_kind,
+            source["optimizers"],
+        )
+        frame[SOURCE_PATH_COLUMN] = source["path"]
+        frame[SOURCE_MANIFEST_COLUMN] = source_manifest["fingerprint"]
+        frame[SOURCE_RESULTS_COLUMN] = source["result_file"]["sha256"]
+        frames.append(frame)
+
+    results = pd.concat(frames, ignore_index=True)
+    _validate_composed_rows(results, manifest)
+    return results
+
+
+def load_reporting_results(results_dir: Path, expected_run_kind: str) -> pd.DataFrame:
+    """Load exactly one ordinary campaign or one composite report source."""
+    if expected_run_kind not in _RESULT_FILENAMES:
+        raise RuntimeError(f"unsupported benchmark run kind {expected_run_kind!r}")
+    if not results_dir.is_dir():
+        raise RuntimeError(f"benchmark results directory is missing: {results_dir}")
+    campaign_exists = (results_dir / MANIFEST_FILENAME).exists()
+    composite_exists = (results_dir / COMPOSITE_MANIFEST_FILENAME).exists()
+    if campaign_exists and composite_exists:
+        raise RuntimeError(
+            "benchmark results directory is ambiguous: it contains campaign and composite manifests"
+        )
+    if not campaign_exists and not composite_exists:
+        raise RuntimeError(
+            "benchmark results directory contains neither a campaign nor composite manifest"
+        )
+    if campaign_exists:
+        return _load_ordinary_results(results_dir, expected_run_kind)
+    return load_composite_results(results_dir, expected_run_kind)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compose compatible benchmark campaigns for authenticated reporting"
+    )
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--base-results-dir", type=Path, required=True)
+    parser.add_argument(
+        "--replacement",
+        action="append",
+        nargs=2,
+        default=[],
+        metavar=("RESULTS_DIR", "OPTIMIZERS"),
+        help="Replacement campaign and comma-separated optimizer names; may be repeated",
+    )
+    args = parser.parse_args()
+    replacements = [
+        (Path(source), [optimizer.strip() for optimizer in names.split(",")])
+        for source, names in args.replacement
+    ]
+    manifest = write_composite_manifest(
+        args.output_dir,
+        args.base_results_dir,
+        replacements,
+    )
+    print(f"Wrote {args.output_dir / COMPOSITE_MANIFEST_FILENAME} ({manifest['fingerprint']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/hola-py/benchmarks/data/persistence.py
+++ b/hola-py/benchmarks/data/persistence.py
@@ -30,6 +30,8 @@ from benchmarks.data.manifest import MANIFEST_FILENAME, validate_manifest
 from benchmarks.data.schema import HPO_COLUMNS, MO_COLUMNS, SO_COLUMNS
 from benchmarks.data.seeding import make_hpo_split_seed, make_seed
 
+SOURCE_RESULT_ROW_INDEX_COLUMN = "_source_result_row_index"
+
 
 class _ResultRow(Protocol):
     """Typed view of the union of persisted benchmark result schemas."""
@@ -104,15 +106,72 @@ class ResultStore:
         """Load a complete, authenticated practical-HPO campaign."""
         return self._load_complete_campaign("hpo", self.load_hpo())
 
+    def load_complete_selected(
+        self,
+        expected_run_kind: str,
+        optimizers: list[str],
+        *,
+        chunksize: int = 64,
+    ) -> pd.DataFrame:
+        """Load and validate one optimizer projection of a campaign.
+
+        Composite reports use this projection so a source campaign can supply
+        only the methods attributed to it. Reading in small chunks avoids
+        materializing excluded convergence traces or Pareto fronts.
+        """
+        manifest = self.load_manifest(expected_run_kind=expected_run_kind)
+        declared = self._manifest_string_axis(manifest, "optimizers")
+        if (
+            not optimizers
+            or any(not isinstance(optimizer, str) or not optimizer for optimizer in optimizers)
+            or len(optimizers) != len(set(optimizers))
+        ):
+            raise RuntimeError("selected optimizers must be a nonempty list of unique strings")
+        unknown = [optimizer for optimizer in optimizers if optimizer not in declared]
+        if unknown:
+            raise RuntimeError(
+                "selected optimizer(s) are absent from the source campaign: " + ", ".join(unknown)
+            )
+        if isinstance(chunksize, bool) or not isinstance(chunksize, int) or chunksize <= 0:
+            raise ValueError("chunksize must be a positive integer")
+
+        path, columns = self._result_path_and_columns(expected_run_kind)
+        if not path.exists():
+            results = pd.DataFrame(columns=columns)
+        else:
+            selected = set(optimizers)
+            chunks: list[pd.DataFrame] = []
+            for chunk in pd.read_csv(path, chunksize=chunksize):
+                if "optimizer" not in chunk:
+                    raise RuntimeError("campaign results are missing required columns: optimizer")
+                projection = chunk.loc[chunk["optimizer"].isin(selected)].copy()
+                if not projection.empty:
+                    projection[SOURCE_RESULT_ROW_INDEX_COLUMN] = projection.index.astype(int)
+                    chunks.append(projection)
+            results = (
+                pd.concat(chunks, ignore_index=True) if chunks else pd.DataFrame(columns=columns)
+            )
+        return self._load_complete_campaign(
+            expected_run_kind,
+            results,
+            manifest=manifest,
+            selected_optimizers=optimizers,
+        )
+
     def _load_complete_campaign(
         self,
         expected_run_kind: str,
         results: pd.DataFrame,
+        *,
+        manifest: dict[str, Any] | None = None,
+        selected_optimizers: list[str] | None = None,
     ) -> pd.DataFrame:
         """Validate exact manifest Cartesian coverage before analysis."""
-        manifest = self.load_manifest(expected_run_kind=expected_run_kind)
+        if manifest is None:
+            manifest = self.load_manifest(expected_run_kind=expected_run_kind)
         problems = self._manifest_string_axis(manifest, "problems")
-        optimizers = self._manifest_string_axis(manifest, "optimizers")
+        declared_optimizers = self._manifest_string_axis(manifest, "optimizers")
+        optimizers = declared_optimizers if selected_optimizers is None else selected_optimizers
         budgets = self._manifest_integer_axis(manifest, "budgets")
         n_runs = manifest.get("n_runs")
         if isinstance(n_runs, bool) or not isinstance(n_runs, int) or n_runs <= 0:
@@ -197,6 +256,7 @@ class ResultStore:
             manifest,
             optimizers,
             budgets,
+            projection=selected_optimizers is not None,
         )
         self._validate_row_configurations(canonical, configurations)
         if expected_run_kind == "hpo":
@@ -209,11 +269,22 @@ class ResultStore:
                 self._validate_multi_objective_contract(canonical)
         return canonical
 
+    def _result_path_and_columns(self, run_kind: str) -> tuple[Path, list[str]]:
+        if run_kind == "single_objective":
+            return self.so_path, SO_COLUMNS
+        if run_kind == "multi_objective":
+            return self.mo_path, MO_COLUMNS
+        if run_kind == "hpo":
+            return self.hpo_path, HPO_COLUMNS
+        raise RuntimeError(f"unsupported benchmark run kind {run_kind!r}")
+
     @staticmethod
     def _manifest_optimizer_configurations(
         manifest: dict[str, Any],
         optimizers: list[str],
         budgets: list[int],
+        *,
+        projection: bool = False,
     ) -> dict[tuple[str, int], dict[str, Any]]:
         """Return the manifest's complete optimizer-by-budget configuration map."""
         entries = manifest.get("optimizer_configurations")
@@ -228,6 +299,8 @@ class ResultStore:
             by_budget = entry.get("by_budget")
             if not isinstance(optimizer, str) or not isinstance(by_budget, list):
                 raise RuntimeError("campaign manifest has a malformed optimizer configuration")
+            if projection and optimizer not in optimizers:
+                continue
             for item in by_budget:
                 if not isinstance(item, dict):
                     raise RuntimeError("campaign manifest has a malformed budget configuration")

--- a/hola-py/benchmarks/plotting/grouped_tlp.py
+++ b/hola-py/benchmarks/plotting/grouped_tlp.py
@@ -24,7 +24,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from benchmarks.data.persistence import ResultStore
+from benchmarks.data.composite import load_reporting_results
 from benchmarks.plotting.bootstrap import (
     DEFAULT_BOOTSTRAP_RESAMPLES,
     DEFAULT_BOOTSTRAP_SEED,
@@ -329,7 +329,7 @@ def main() -> None:
 
     # Authenticate the manifest and exact Cartesian result coverage before
     # creating any reporting artifacts.
-    results = ResultStore(args.results_dir).load_complete_multi()
+    results = load_reporting_results(args.results_dir, "multi_objective")
     summary = summarize_grouped_tlp(
         results,
         n_resamples=args.bootstrap_resamples,

--- a/hola-py/benchmarks/plotting/hpo.py
+++ b/hola-py/benchmarks/plotting/hpo.py
@@ -22,7 +22,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from benchmarks.data.persistence import ResultStore
+from benchmarks.data.composite import load_reporting_results
 from benchmarks.plotting.bootstrap import (
     DEFAULT_BOOTSTRAP_RESAMPLES,
     DEFAULT_BOOTSTRAP_SEED,
@@ -134,7 +134,7 @@ def main() -> None:
 
     # Authenticate the manifest and exact Cartesian result coverage before
     # creating any reporting artifacts.
-    results = ResultStore(args.results_dir).load_complete_hpo()
+    results = load_reporting_results(args.results_dir, "hpo")
     summaries = summarize_hpo(
         results,
         n_resamples=args.bootstrap_resamples,

--- a/hola-py/benchmarks/plotting/multi_objective.py
+++ b/hola-py/benchmarks/plotting/multi_objective.py
@@ -23,8 +23,14 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from benchmarks.data.composite import (
+    SOURCE_MANIFEST_COLUMN,
+    SOURCE_PATH_COLUMN,
+    SOURCE_RESULTS_COLUMN,
+    load_reporting_results,
+)
 from benchmarks.data.normalize import lexicographic_failure_ranks
-from benchmarks.data.persistence import ResultStore
+from benchmarks.data.persistence import SOURCE_RESULT_ROW_INDEX_COLUMN
 from benchmarks.plotting.export import save_figure
 from benchmarks.plotting.style import apply_paper_style, get_color
 from benchmarks.problems.multi_objective import MULTI_OBJECTIVE_PROBLEMS
@@ -57,6 +63,9 @@ REPRESENTATIVE_SELECTION_COLUMNS = [
     "budget",
     "selection_status",
     "source_result_row_index",
+    SOURCE_PATH_COLUMN,
+    SOURCE_MANIFEST_COLUMN,
+    SOURCE_RESULTS_COLUMN,
     "run_id",
     "seed",
     "result_status",
@@ -131,6 +140,17 @@ def _failure_errors(rows: pd.DataFrame) -> str:
     return " | ".join(sorted(errors))
 
 
+def _source_metadata(rows: pd.DataFrame) -> dict[str, object]:
+    metadata: dict[str, object] = {}
+    for column in (SOURCE_PATH_COLUMN, SOURCE_MANIFEST_COLUMN, SOURCE_RESULTS_COLUMN):
+        if column not in rows:
+            metadata[column] = None
+            continue
+        values = rows[column].dropna().unique()
+        metadata[column] = values[0] if len(values) == 1 else None
+    return metadata
+
+
 def _empty_representative_selection(
     problem: str,
     optimizer: str,
@@ -146,6 +166,7 @@ def _empty_representative_selection(
         "budget": budget,
         "selection_status": status,
         "source_result_row_index": None,
+        **_source_metadata(optimizer_rows),
         "run_id": None,
         "seed": None,
         "result_status": None,
@@ -198,7 +219,8 @@ def representative_terminal_front_tables(
         raise ValueError(f"unknown representative-front problems: {', '.join(unknown)}")
 
     values = results.copy()
-    values["_source_result_row_index"] = np.arange(len(values), dtype=int)
+    if SOURCE_RESULT_ROW_INDEX_COLUMN not in values:
+        values[SOURCE_RESULT_ROW_INDEX_COLUMN] = np.arange(len(values), dtype=int)
     optimizers = sorted(str(value) for value in values["optimizer"].dropna().unique())
     selection_rows: list[dict[str, object]] = []
     point_rows: list[dict[str, object]] = []
@@ -322,7 +344,8 @@ def representative_terminal_front_tables(
                     "optimizer": optimizer,
                     "budget": largest_budget,
                     "selection_status": selection_status,
-                    "source_result_row_index": int(chosen["_source_result_row_index"]),
+                    "source_result_row_index": int(chosen[SOURCE_RESULT_ROW_INDEX_COLUMN]),
+                    **_source_metadata(chosen.to_frame().T),
                     "run_id": run_id,
                     "seed": seed,
                     "result_status": str(chosen["status"]),
@@ -721,8 +744,7 @@ def main() -> None:
     parser.add_argument("--output-dir", type=Path, default=Path("benchmark_results/plots"))
     args = parser.parse_args()
 
-    store = ResultStore(args.results_dir)
-    df = store.load_complete_multi()
+    df = load_reporting_results(args.results_dir, "multi_objective")
 
     write_failure_table(df, args.output_dir)
     if df["problem"].isin(REPRESENTATIVE_FRONT_PROBLEMS).any():

--- a/hola-py/benchmarks/plotting/single_objective.py
+++ b/hola-py/benchmarks/plotting/single_objective.py
@@ -21,6 +21,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from benchmarks.data.composite import load_reporting_results
 from benchmarks.data.normalize import (
     GMM_MECHANISM_COMPARATORS,
     GMM_OPTIMIZER,
@@ -29,7 +30,6 @@ from benchmarks.data.normalize import (
     aggregate_family_balanced_ranks,
     summarize_regret,
 )
-from benchmarks.data.persistence import ResultStore
 from benchmarks.plotting.export import save_figure
 from benchmarks.plotting.style import apply_paper_style, get_color
 from benchmarks.problems.single_objective import SINGLE_OBJECTIVE_PROBLEMS
@@ -260,8 +260,7 @@ def main() -> None:
     parser.add_argument("--output-dir", type=Path, default=Path("benchmark_results/plots"))
     args = parser.parse_args()
 
-    store = ResultStore(args.results_dir)
-    df = store.load_complete_single()
+    df = load_reporting_results(args.results_dir, "single_objective")
 
     regret = add_simple_regret(df, SINGLE_OBJECTIVE_PROBLEMS)
     summary = summarize_regret(regret)

--- a/hola-py/tests/test_benchmark_composite.py
+++ b/hola-py/tests/test_benchmark_composite.py
@@ -1,0 +1,477 @@
+# Copyright 2026 BlackRock, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Method-level provenance and virtual-union reporting checks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from benchmarks.data.composite import (  # noqa: E402
+    COMPOSITE_MANIFEST_FILENAME,
+    SOURCE_MANIFEST_COLUMN,
+    SOURCE_PATH_COLUMN,
+    SOURCE_RESULTS_COLUMN,
+    build_composite_manifest,
+    load_reporting_results,
+    validate_composite_manifest,
+    write_composite_manifest,
+)
+from benchmarks.data.manifest import attach_fingerprint, build_campaign_manifest  # noqa: E402
+from benchmarks.data.persistence import ResultStore  # noqa: E402
+from benchmarks.data.seeding import make_hpo_split_seed, make_seed  # noqa: E402
+from benchmarks.plotting.multi_objective import (  # noqa: E402
+    representative_terminal_front_tables,
+)
+
+pytestmark = pytest.mark.benchmarks
+
+
+def _provenance(label: str) -> dict[str, Any]:
+    return {
+        "code": {"commit": label, "dirty": False, "source_hash": f"source-{label}"},
+        "lock_hash": "lock",
+        "python": {"implementation": "CPython", "version": "test"},
+        "platform": {"platform": "test", "machine": "test", "system": "test"},
+        "dependencies": {"hola-opt": "test"},
+        "native_extension": {
+            "module": "hola_opt.hola_opt",
+            "filename": "hola_opt.abi3.so",
+            "byte_size": 4,
+            "sha256": "0" * 64,
+        },
+    }
+
+
+def _single_manifest(
+    optimizers: list[str],
+    *,
+    budget: int = 2,
+    campaign_configuration: dict[str, Any] | None = None,
+    provenance_label: str = "source",
+) -> dict[str, Any]:
+    return build_campaign_manifest(
+        run_kind="single_objective",
+        budgets=[budget],
+        n_runs=1,
+        problem_names=["forrester_1d"],
+        optimizer_names=optimizers,
+        optimizer_configurations=[
+            {
+                "optimizer": optimizer,
+                "by_budget": [
+                    {
+                        "budget": budget,
+                        "configuration": {"adapter": optimizer, "budget": budget},
+                    }
+                ],
+            }
+            for optimizer in optimizers
+        ],
+        campaign_configuration=campaign_configuration,
+        provenance=_provenance(provenance_label),
+    )
+
+
+def _single_row(optimizer: str, value: float, *, budget: int = 2) -> dict[str, Any]:
+    return {
+        "problem": "forrester_1d",
+        "optimizer": optimizer,
+        "budget": budget,
+        "run_id": 0,
+        "seed": make_seed("forrester_1d", budget, 0),
+        "status": "success",
+        "error": "",
+        "optimizer_config": {"adapter": optimizer, "budget": budget},
+        "n_evaluations": budget,
+        "best_value": value,
+        "best_params": {"x": 0.5},
+        "wall_time_seconds": 0.1,
+        "convergence_trace": [value] * budget,
+    }
+
+
+def _write_single_campaign(
+    path: Path,
+    values: dict[str, float],
+    *,
+    budget: int = 2,
+    campaign_configuration: dict[str, Any] | None = None,
+    provenance_label: str = "source",
+) -> ResultStore:
+    store = ResultStore(path)
+    store.prepare_campaign(
+        _single_manifest(
+            list(values),
+            budget=budget,
+            campaign_configuration=campaign_configuration,
+            provenance_label=provenance_label,
+        ),
+        resume=False,
+    )
+    for optimizer, value in values.items():
+        store.append_single(_single_row(optimizer, value, budget=budget))
+    return store
+
+
+def _write_hpo_campaign(
+    path: Path,
+    values: dict[str, float],
+    *,
+    provenance_label: str,
+) -> ResultStore:
+    budget = 2
+    problem = "gbr_diabetes_hpo"
+    configuration = {"benchmark": "fixed-split"}
+    manifest = build_campaign_manifest(
+        run_kind="hpo",
+        budgets=[budget],
+        n_runs=1,
+        problem_names=[problem],
+        optimizer_names=list(values),
+        optimizer_configurations=[
+            {
+                "optimizer": optimizer,
+                "by_budget": [
+                    {
+                        "budget": budget,
+                        "configuration": {"adapter": optimizer, "budget": budget},
+                    }
+                ],
+            }
+            for optimizer in values
+        ],
+        campaign_configuration=configuration,
+        provenance=_provenance(provenance_label),
+    )
+    store = ResultStore(path)
+    store.prepare_campaign(manifest, resume=False)
+    for optimizer, value in values.items():
+        store.append_hpo(
+            {
+                "problem": problem,
+                "optimizer": optimizer,
+                "budget": budget,
+                "run_id": 0,
+                "search_seed": make_seed(problem, budget, 0),
+                "split_seed": make_hpo_split_seed(problem, 0),
+                "status": "success",
+                "error": "",
+                "optimizer_config": {"adapter": optimizer, "budget": budget},
+                "n_validation_evaluations": budget,
+                "best_validation_r2": value,
+                "best_params": {"depth": 2},
+                "validation_trace": [value] * budget,
+                "heldout_test_r2": value - 0.1,
+                "n_heldout_evaluations": 1,
+                "train_size": 10,
+                "validation_size": 5,
+                "test_size": 5,
+                "wall_time_seconds": 0.1,
+            }
+        )
+    return store
+
+
+def _write_multi_campaign(
+    path: Path,
+    values: dict[str, float],
+    *,
+    provenance_label: str,
+) -> ResultStore:
+    budget = 2
+    problem = "zdt3_30d"
+    manifest = build_campaign_manifest(
+        run_kind="multi_objective",
+        budgets=[budget],
+        n_runs=1,
+        problem_names=[problem],
+        optimizer_names=list(values),
+        optimizer_configurations=[
+            {
+                "optimizer": optimizer,
+                "by_budget": [
+                    {
+                        "budget": budget,
+                        "configuration": {"adapter": optimizer, "budget": budget},
+                    }
+                ],
+            }
+            for optimizer in values
+        ],
+        provenance=_provenance(provenance_label),
+    )
+    store = ResultStore(path)
+    store.prepare_campaign(manifest, resume=False)
+    for optimizer, value in values.items():
+        store.append_multi(
+            {
+                "problem": problem,
+                "optimizer": optimizer,
+                "budget": budget,
+                "run_id": 0,
+                "seed": make_seed(problem, budget, 0),
+                "status": "success",
+                "error": "",
+                "optimizer_config": {"adapter": optimizer, "budget": budget},
+                "n_evaluations": budget,
+                "pareto_front": [[value, 1.0 - value]],
+                "decision_vectors": [[0.5] * 30],
+                "normalized_hypervolume_gap": value,
+                "normalized_igd": value + 0.1,
+                "spacing": 0.05,
+                "wall_time_seconds": 0.1,
+                "n_pareto_points": 1,
+            }
+        )
+    return store
+
+
+def _compose_single(tmp_path: Path) -> tuple[Path, ResultStore, ResultStore]:
+    base = _write_single_campaign(
+        tmp_path / "base",
+        {"baseline": 1.0, "gmm": 100.0},
+        provenance_label="base",
+    )
+    replacement = _write_single_campaign(
+        tmp_path / "replacement",
+        {"gmm": -1.0},
+        provenance_label="replacement",
+    )
+    composite = tmp_path / "composite"
+    write_composite_manifest(
+        composite,
+        base.output_dir,
+        [(replacement.output_dir, ["gmm"])],
+    )
+    return composite, base, replacement
+
+
+def test_composite_replaces_only_selected_method_and_records_row_sources(tmp_path: Path) -> None:
+    composite, base, replacement = _compose_single(tmp_path)
+
+    results = load_reporting_results(composite, "single_objective").set_index("optimizer")
+
+    assert results.loc["baseline", "best_value"] == 1.0
+    assert results.loc["gmm", "best_value"] == -1.0
+    assert results.loc["baseline", SOURCE_PATH_COLUMN] == "../base"
+    assert results.loc["gmm", SOURCE_PATH_COLUMN] == "../replacement"
+    assert results.loc["baseline", SOURCE_MANIFEST_COLUMN] == base.load_manifest()["fingerprint"]
+    assert results.loc["gmm", SOURCE_MANIFEST_COLUMN] == replacement.load_manifest()["fingerprint"]
+    assert results[SOURCE_RESULTS_COLUMN].map(lambda value: len(value) == 64).all()
+    assert not (composite / "single_objective.csv").exists()
+
+    manifest = json.loads((composite / COMPOSITE_MANIFEST_FILENAME).read_text())
+    assert manifest["optimizers"] == ["baseline", "gmm"]
+    assert [source["optimizers"] for source in manifest["sources"]] == [
+        ["baseline"],
+        ["gmm"],
+    ]
+    assert all(not Path(source["path"]).is_absolute() for source in manifest["sources"])
+
+
+def test_composite_paths_remain_valid_when_the_result_bundle_moves(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    composite, _, _ = _compose_single(bundle)
+    moved = tmp_path / "moved"
+    bundle.rename(moved)
+
+    results = load_reporting_results(moved / composite.name, "single_objective")
+
+    assert set(results["optimizer"]) == {"baseline", "gmm"}
+
+
+def test_composite_refuses_manifest_source_and_result_tampering(tmp_path: Path) -> None:
+    composite, base, replacement = _compose_single(tmp_path)
+    composite_path = composite / COMPOSITE_MANIFEST_FILENAME
+
+    payload = json.loads(composite_path.read_text())
+    payload["optimizers"].reverse()
+    composite_path.write_text(json.dumps(payload))
+    with pytest.raises(RuntimeError, match="composite manifest fingerprint"):
+        load_reporting_results(composite, "single_objective")
+
+    payload["optimizers"].reverse()
+    composite_path.write_text(json.dumps(attach_fingerprint(payload)))
+    source_manifest = replacement.load_manifest()
+    source_manifest["provenance"]["code"]["commit"] = "changed"
+    replacement.manifest_path.write_text(json.dumps(attach_fingerprint(source_manifest)))
+    with pytest.raises(RuntimeError, match="source campaign fingerprint changed"):
+        load_reporting_results(composite, "single_objective")
+
+    # Restore the exact source identity recorded by rebuilding the composition.
+    replacement.manifest_path.write_text(
+        json.dumps(_single_manifest(["gmm"], provenance_label="replacement"))
+    )
+    composite_path.unlink()
+    write_composite_manifest(composite, base.output_dir, [(replacement.output_dir, ["gmm"])])
+    with replacement.so_path.open("a") as result_file:
+        result_file.write("\n")
+    with pytest.raises(RuntimeError, match="source result artifact changed"):
+        load_reporting_results(composite, "single_objective")
+
+
+@pytest.mark.parametrize(
+    ("replacement_budget", "replacement_configuration", "changed_field"),
+    [
+        (3, {"variant": "base"}, "budgets"),
+        (2, {"variant": "other"}, "campaign_configuration"),
+    ],
+)
+def test_composite_builder_rejects_incompatible_campaign_contracts(
+    tmp_path: Path,
+    replacement_budget: int,
+    replacement_configuration: dict[str, Any],
+    changed_field: str,
+) -> None:
+    base = _write_single_campaign(
+        tmp_path / "base",
+        {"baseline": 1.0, "gmm": 2.0},
+        campaign_configuration={"variant": "base"},
+    )
+    replacement = _write_single_campaign(
+        tmp_path / "replacement",
+        {"gmm": -1.0},
+        budget=replacement_budget,
+        campaign_configuration=replacement_configuration,
+    )
+
+    with pytest.raises(RuntimeError, match=rf"changed fields:.*{changed_field}"):
+        build_composite_manifest(
+            tmp_path / "composite",
+            base.output_dir,
+            [(replacement.output_dir, ["gmm"])],
+        )
+
+
+def test_composite_builder_rejects_missing_and_duplicate_replacements(tmp_path: Path) -> None:
+    base = _write_single_campaign(tmp_path / "base", {"baseline": 1.0, "gmm": 2.0})
+    replacement = _write_single_campaign(tmp_path / "replacement", {"baseline": -1.0})
+
+    with pytest.raises(RuntimeError, match="absent from the source campaign"):
+        build_composite_manifest(
+            tmp_path / "missing",
+            base.output_dir,
+            [(replacement.output_dir, ["gmm"])],
+        )
+    with pytest.raises(RuntimeError, match="assigned more than once"):
+        build_composite_manifest(
+            tmp_path / "duplicate",
+            base.output_dir,
+            [
+                (base.output_dir, ["gmm"]),
+                (base.output_dir, ["gmm"]),
+            ],
+        )
+
+
+def test_composite_builder_rejects_incomplete_sources_before_writing(tmp_path: Path) -> None:
+    base = _write_single_campaign(tmp_path / "base", {"baseline": 1.0, "gmm": 2.0})
+    incomplete = ResultStore(tmp_path / "incomplete")
+    incomplete.prepare_campaign(_single_manifest(["gmm"]), resume=False)
+    output = tmp_path / "composite"
+
+    with pytest.raises(RuntimeError, match="campaign results are incomplete"):
+        write_composite_manifest(
+            output,
+            base.output_dir,
+            [(incomplete.output_dir, ["gmm"])],
+        )
+
+    assert not output.exists()
+
+
+def test_composite_validation_rejects_absolute_paths_and_ambiguous_directories(
+    tmp_path: Path,
+) -> None:
+    composite, base, _ = _compose_single(tmp_path)
+    composite_path = composite / COMPOSITE_MANIFEST_FILENAME
+    payload = json.loads(composite_path.read_text())
+    payload["sources"][0]["path"] = str(base.output_dir.resolve())
+    payload = attach_fingerprint(payload)
+
+    with pytest.raises(RuntimeError, match="relative POSIX"):
+        validate_composite_manifest(payload)
+
+    (composite / "campaign_manifest.json").write_text("{}")
+    with pytest.raises(RuntimeError, match="ambiguous"):
+        load_reporting_results(composite, "single_objective")
+
+
+def test_composite_projection_preserves_source_row_contract_validation(tmp_path: Path) -> None:
+    composite, _, replacement = _compose_single(tmp_path)
+    rows = pd.read_csv(replacement.so_path)
+    rows.loc[0, "seed"] = int(rows.loc[0, "seed"]) + 1
+    rows.to_csv(replacement.so_path, index=False)
+    payload = json.loads((composite / COMPOSITE_MANIFEST_FILENAME).read_text())
+    payload["sources"][1]["result_file"]["byte_size"] = replacement.so_path.stat().st_size
+    payload["sources"][1]["result_file"]["sha256"] = hashlib.sha256(
+        replacement.so_path.read_bytes()
+    ).hexdigest()
+    (composite / COMPOSITE_MANIFEST_FILENAME).write_text(json.dumps(attach_fingerprint(payload)))
+
+    with pytest.raises(RuntimeError, match="seed does not match deterministic derivation"):
+        load_reporting_results(composite, "single_objective")
+
+
+def test_hpo_composite_uses_the_same_dispatch_and_campaign_configuration(tmp_path: Path) -> None:
+    base = _write_hpo_campaign(
+        tmp_path / "base",
+        {"baseline": 0.4, "gmm": 0.1},
+        provenance_label="base",
+    )
+    replacement = _write_hpo_campaign(
+        tmp_path / "replacement",
+        {"gmm": 0.8},
+        provenance_label="replacement",
+    )
+    composite = tmp_path / "composite"
+    write_composite_manifest(
+        composite,
+        base.output_dir,
+        [(replacement.output_dir, ["gmm"])],
+    )
+
+    results = load_reporting_results(composite, "hpo").set_index("optimizer")
+
+    assert results.loc["baseline", "best_validation_r2"] == 0.4
+    assert results.loc["gmm", "best_validation_r2"] == 0.8
+    with pytest.raises(RuntimeError, match="expected a multi_objective report"):
+        load_reporting_results(composite, "multi_objective")
+
+
+def test_multi_composite_preserves_source_row_identity_in_front_audit(tmp_path: Path) -> None:
+    base = _write_multi_campaign(
+        tmp_path / "base",
+        {"baseline": 0.4, "gmm": 0.8},
+        provenance_label="base",
+    )
+    replacement = _write_multi_campaign(
+        tmp_path / "replacement",
+        {"gmm": 0.2},
+        provenance_label="replacement",
+    )
+    composite = tmp_path / "composite"
+    write_composite_manifest(
+        composite,
+        base.output_dir,
+        [(replacement.output_dir, ["gmm"])],
+    )
+
+    results = load_reporting_results(composite, "multi_objective")
+    selections, points = representative_terminal_front_tables(results, ["zdt3_30d"])
+    gmm = selections.set_index("optimizer").loc["gmm"]
+
+    assert gmm["normalized_hypervolume_gap"] == 0.2
+    assert gmm["source_result_row_index"] == 0
+    assert gmm[SOURCE_PATH_COLUMN] == "../replacement"
+    assert gmm[SOURCE_MANIFEST_COLUMN] == replacement.load_manifest()["fingerprint"]
+    assert len(gmm[SOURCE_RESULTS_COLUMN]) == 64
+    assert len(points[points["optimizer"].eq("gmm")]) == 1

--- a/hola-py/tests/test_benchmarks_smoke.py
+++ b/hola-py/tests/test_benchmarks_smoke.py
@@ -17,6 +17,7 @@ BENCHMARK_MODULES = (
     "benchmarks.adapters.pymoo_common",
     "benchmarks.adapters.pymoo_multi",
     "benchmarks.adapters.pymoo_single",
+    "benchmarks.data.composite",
     "benchmarks.data.manifest",
     "benchmarks.data.normalize",
     "benchmarks.data.persistence",
@@ -70,6 +71,32 @@ def test_benchmark_cli_help(isolated_benchmarks_path, isolated_benchmarks_env):
     assert "run-grouped-tlp" in result.stdout
     assert "plot-hpo" in result.stdout
     assert "plot-grouped-tlp" in result.stdout
+
+
+@pytest.mark.benchmarks
+@pytest.mark.parametrize(
+    ("command", "expected_option"),
+    [
+        ("run-single", "--optimizers"),
+        ("compose-results", "--replacement"),
+    ],
+)
+def test_benchmark_subcommand_help_reaches_the_command_parser(
+    isolated_benchmarks_path,
+    isolated_benchmarks_env,
+    command: str,
+    expected_option: str,
+):
+    result = subprocess.run(
+        [sys.executable, "-m", "benchmarks", command, "--help"],
+        cwd=str(isolated_benchmarks_path),
+        env=isolated_benchmarks_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert expected_option in result.stdout
 
 
 @pytest.mark.benchmarks

--- a/hola-py/tests/test_multiobjective_representative_fronts.py
+++ b/hola-py/tests/test_multiobjective_representative_fronts.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
@@ -197,8 +196,8 @@ def test_plot_multi_writes_selected_row_and_metrics_to_audit_csv(
     )
     monkeypatch.setattr(
         multi_plotting,
-        "ResultStore",
-        lambda _: SimpleNamespace(load_complete_multi=lambda: results),
+        "load_reporting_results",
+        lambda *_: results,
     )
     monkeypatch.setattr(multi_plotting, "plot_metric_by_budget", lambda *args: None)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- add a report-level composite manifest that partitions optimizer methods across compatible source campaigns
- bind each source campaign fingerprint and exact result CSV digest without copying or relabeling rows
- validate protocol compatibility, selected Cartesian coverage, row contracts, paired seeds, and non-overlapping method assignments
- load selected projections in small CSV chunks and preserve source-local row provenance in representative-front audits
- make benchmark subcommand help reach each real command parser

## Why
Campaign manifests should remain strict for resuming one executable campaign. Reporting should be compositional: unchanged baselines can remain attributed to their original campaign while a changed method is rerun under a new campaign. This change adds that missing report-level granularity without changing benchmark execution semantics or protocol version 6.

## Validation
- uv run --directory hola-py ruff check .
- uv run --directory hola-py ty check benchmarks tests
- uv run --directory hola-py pytest -q: 425 passed, 4 skipped
- compose-results and plot-single end-to-end smoke against an existing protocol-6 sentinel
- composed multi-objective report smoke with source-local representative-front row audit