### PR TITLE
Add paired benchmark audit tables

### DIFF
--- a/hola-py/benchmarks/plotting/bootstrap.py
+++ b/hola-py/benchmarks/plotting/bootstrap.py
@@ -27,7 +27,7 @@ DEFAULT_CONFIDENCE_LEVEL = 0.95
 BOOTSTRAP_METHOD = "paired run-id resampling; median; percentile interval"
 
 
-def _problem_context_seed(seed: int, problem: str) -> int:
+def problem_context_seed(seed: int, problem: str) -> int:
     """Domain-separate a stable bootstrap stream for one problem."""
     material = f"paired-bootstrap:{seed}:{problem}".encode()
     return int(hashlib.sha256(material).hexdigest()[:16], 16)
@@ -92,7 +92,7 @@ def paired_median_summary(
                     f"problem {problem!r} does not have the same run IDs in every cell"
                 )
 
-        context_seed = _problem_context_seed(seed, problem)
+        context_seed = problem_context_seed(seed, problem)
         generator = np.random.default_rng(context_seed)
         draws = generator.integers(0, len(run_ids), size=(n_resamples, len(run_ids)))
 

--- a/hola-py/benchmarks/plotting/hpo.py
+++ b/hola-py/benchmarks/plotting/hpo.py
@@ -16,6 +16,8 @@
 from __future__ import annotations
 
 import argparse
+import warnings
+from collections.abc import Sequence
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -26,7 +28,9 @@ from benchmarks.data.composite import load_reporting_results
 from benchmarks.plotting.bootstrap import (
     DEFAULT_BOOTSTRAP_RESAMPLES,
     DEFAULT_BOOTSTRAP_SEED,
+    DEFAULT_CONFIDENCE_LEVEL,
     paired_median_summary,
+    problem_context_seed,
 )
 from benchmarks.plotting.export import save_figure
 from benchmarks.plotting.style import apply_paper_style, get_color
@@ -40,6 +44,16 @@ HPO_METRICS = {
 HPO_PROBLEM_LABELS = {
     "gbr_diabetes_hpo": "Gradient-boosted regression on diabetes",
 }
+HPO_GMM_OPTIMIZER = "HOLA HPO (GMM)"
+HPO_GMM_COMPARATORS = (
+    "HOLA HPO (random)",
+    "HOLA HPO (sobol)",
+    "Optuna HPO (TPE)",
+)
+HPO_PAIRED_DIFFERENCE_BOOTSTRAP_METHOD = (
+    "paired run-id resampling; median of paired differences; percentile interval"
+)
+HPO_BUDGET_CHANGE = (25, 100)
 HPO_FAILURE_COLUMNS = [
     "problem",
     "optimizer",
@@ -75,6 +89,300 @@ def hpo_failure_table(results: pd.DataFrame) -> pd.DataFrame:
     """Return one audit row for every failed HPO outcome."""
     columns = [column for column in HPO_FAILURE_COLUMNS if column in results]
     return results.loc[results["status"].eq("error"), columns].copy()
+
+
+def _validated_hpo_metric_values(results: pd.DataFrame, metric: str) -> pd.DataFrame:
+    required = {"problem", "optimizer", "budget", "run_id", "status", metric}
+    missing = required - set(results.columns)
+    if missing:
+        raise ValueError(f"HPO paired contrast is missing columns: {', '.join(sorted(missing))}")
+    if results.empty:
+        raise ValueError("HPO paired contrast requires at least one result row")
+    key_columns = ["problem", "optimizer", "budget", "run_id"]
+    if results.duplicated(key_columns).any():
+        raise ValueError("HPO paired contrast requires unique campaign run keys")
+    invalid_status = results["status"].isna() | ~results["status"].isin({"success", "error"})
+    if invalid_status.any():
+        raise ValueError("HPO paired contrast encountered an invalid result status")
+
+    values = results.copy()
+    numeric_metric = pd.to_numeric(values[metric], errors="coerce")
+    successful = values["status"].eq("success")
+    if (successful & ~np.isfinite(numeric_metric)).any():
+        raise ValueError(f"successful HPO runs must have a finite {metric}")
+    values["_metric"] = numeric_metric.where(successful)
+
+    for problem_key, problem_rows in values.groupby("problem", sort=True):
+        problem = str(problem_key)
+        expected_run_ids = set(int(value) for value in problem_rows["run_id"])
+        for _, cell in problem_rows.groupby(["optimizer", "budget"], sort=False):
+            if set(int(value) for value in cell["run_id"]) != expected_run_ids:
+                raise ValueError(
+                    f"problem {problem!r} does not have the same run IDs in every HPO cell"
+                )
+    return values
+
+
+def _paired_hpo_cells(
+    left: pd.DataFrame,
+    right: pd.DataFrame,
+    *,
+    require_shared_search_seed: bool,
+) -> pd.DataFrame:
+    metadata = [
+        column for column in ("search_seed", "split_seed") if column in left and column in right
+    ]
+    selected_columns = ["problem", "run_id", "status", "_metric", *metadata]
+    paired = left[selected_columns].merge(
+        right[selected_columns],
+        on=["problem", "run_id"],
+        how="outer",
+        validate="one_to_one",
+        indicator=True,
+        suffixes=("_focal", "_reference"),
+    )
+    if not paired["_merge"].eq("both").all():
+        raise ValueError("HPO paired contrast encountered unpaired runs")
+    paired = paired.drop(columns="_merge")
+    if (
+        "split_seed_focal" in paired
+        and not paired["split_seed_focal"].eq(paired["split_seed_reference"]).all()
+    ):
+        raise ValueError("HPO paired contrast requires a shared split seed")
+    if (
+        require_shared_search_seed
+        and "search_seed_focal" in paired
+        and not paired["search_seed_focal"].eq(paired["search_seed_reference"]).all()
+    ):
+        raise ValueError("HPO optimizer contrast requires a shared search seed")
+
+    complete = paired["status_focal"].eq("success") & paired["status_reference"].eq("success")
+    paired["_difference"] = (paired["_metric_focal"] - paired["_metric_reference"]).where(complete)
+    return paired.sort_values("run_id", ignore_index=True)
+
+
+def _paired_difference_statistics(
+    paired: pd.DataFrame,
+    *,
+    draws: np.ndarray,
+    confidence_level: float,
+) -> dict[str, object]:
+    differences = paired["_difference"].to_numpy(dtype=float)
+    finite = np.isfinite(differences)
+    if finite.any():
+        estimate = float(np.nanmedian(differences))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            bootstrap = np.nanmedian(differences[draws], axis=1)
+        finite_bootstrap = bootstrap[np.isfinite(bootstrap)]
+        valid_resamples = len(finite_bootstrap)
+        if valid_resamples:
+            alpha = (1.0 - confidence_level) / 2.0
+            lower, upper = np.quantile(finite_bootstrap, [alpha, 1.0 - alpha])
+            ci_lower = float(lower)
+            ci_upper = float(upper)
+        else:
+            ci_lower = float("nan")
+            ci_upper = float("nan")
+    else:
+        estimate = float("nan")
+        ci_lower = float("nan")
+        ci_upper = float("nan")
+        valid_resamples = 0
+
+    return {
+        "median_paired_difference": estimate,
+        "ci_lower": ci_lower,
+        "ci_upper": ci_upper,
+        "n_total_pairs": len(paired),
+        "n_complete_pairs": int(finite.sum()),
+        "n_incomplete_pairs": int((~finite).sum()),
+        "n_focal_failures": int(paired["status_focal"].eq("error").sum()),
+        "n_reference_failures": int(paired["status_reference"].eq("error").sum()),
+        "bootstrap_valid_resamples": valid_resamples,
+    }
+
+
+def _bootstrap_draws(
+    run_ids: Sequence[int],
+    *,
+    context_seed: int,
+    n_resamples: int,
+) -> np.ndarray:
+    generator = np.random.default_rng(context_seed)
+    return generator.integers(0, len(run_ids), size=(n_resamples, len(run_ids)))
+
+
+def summarize_hpo_optimizer_contrasts(
+    results: pd.DataFrame,
+    *,
+    focal_optimizer: str = HPO_GMM_OPTIMIZER,
+    comparators: Sequence[str] = HPO_GMM_COMPARATORS,
+    metrics: Sequence[str] = tuple(HPO_METRICS),
+    n_resamples: int = DEFAULT_BOOTSTRAP_RESAMPLES,
+    confidence_level: float = DEFAULT_CONFIDENCE_LEVEL,
+    seed: int = DEFAULT_BOOTSTRAP_SEED,
+) -> pd.DataFrame:
+    """Report paired GMM-minus-comparator median differences at each budget."""
+    if (
+        not comparators
+        or focal_optimizer in comparators
+        or len(set(comparators)) != len(comparators)
+    ):
+        raise ValueError("HPO optimizer contrast names must be non-empty and distinct")
+    if not metrics:
+        raise ValueError("HPO optimizer contrasts require at least one metric")
+    if n_resamples <= 0:
+        raise ValueError("bootstrap resamples must be positive")
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("bootstrap confidence level must be between zero and one")
+
+    rows: list[dict[str, object]] = []
+    for metric in metrics:
+        values = _validated_hpo_metric_values(results, metric)
+        available = set(values["optimizer"])
+        missing = {focal_optimizer, *comparators} - available
+        if missing:
+            raise ValueError("HPO optimizer contrasts omit " + ", ".join(sorted(missing)))
+        for problem_key, problem_rows in values.groupby("problem", sort=True):
+            problem = str(problem_key)
+            run_ids = sorted(int(value) for value in problem_rows["run_id"].unique())
+            context_seed = problem_context_seed(seed, problem)
+            draws = _bootstrap_draws(
+                run_ids,
+                context_seed=context_seed,
+                n_resamples=n_resamples,
+            )
+            for budget_key in sorted(problem_rows["budget"].unique()):
+                budget = int(budget_key)
+                focal = problem_rows[
+                    problem_rows["optimizer"].eq(focal_optimizer)
+                    & problem_rows["budget"].eq(budget)
+                ]
+                for comparator in comparators:
+                    reference = problem_rows[
+                        problem_rows["optimizer"].eq(comparator) & problem_rows["budget"].eq(budget)
+                    ]
+                    paired = _paired_hpo_cells(
+                        focal,
+                        reference,
+                        require_shared_search_seed=True,
+                    )
+                    rows.append(
+                        {
+                            "problem": problem,
+                            "metric": metric,
+                            "metric_direction": "higher_is_better",
+                            "contrast_type": "optimizer_at_fixed_budget",
+                            "focal_optimizer": focal_optimizer,
+                            "reference_optimizer": comparator,
+                            "budget": budget,
+                            "difference_definition": "focal_optimizer - reference_optimizer",
+                            "positive_difference_favors": "focal_optimizer",
+                            **_paired_difference_statistics(
+                                paired,
+                                draws=draws,
+                                confidence_level=confidence_level,
+                            ),
+                            "confidence_level": confidence_level,
+                            "bootstrap_resamples": n_resamples,
+                            "bootstrap_method": HPO_PAIRED_DIFFERENCE_BOOTSTRAP_METHOD,
+                            "bootstrap_seed": seed,
+                            "bootstrap_context_seed": context_seed,
+                        }
+                    )
+    return pd.DataFrame(rows).sort_values(
+        ["metric", "reference_optimizer", "budget"],
+        ignore_index=True,
+    )
+
+
+def summarize_hpo_budget_changes(
+    results: pd.DataFrame,
+    *,
+    earlier_budget: int = HPO_BUDGET_CHANGE[0],
+    later_budget: int = HPO_BUDGET_CHANGE[1],
+    metrics: Sequence[str] = tuple(HPO_METRICS),
+    n_resamples: int = DEFAULT_BOOTSTRAP_RESAMPLES,
+    confidence_level: float = DEFAULT_CONFIDENCE_LEVEL,
+    seed: int = DEFAULT_BOOTSTRAP_SEED,
+) -> pd.DataFrame:
+    """Report paired later-minus-earlier HPO budget changes for every optimizer."""
+    if later_budget <= earlier_budget:
+        raise ValueError("the later HPO budget must exceed the earlier budget")
+    if not metrics:
+        raise ValueError("HPO budget changes require at least one metric")
+    if n_resamples <= 0:
+        raise ValueError("bootstrap resamples must be positive")
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("bootstrap confidence level must be between zero and one")
+
+    rows: list[dict[str, object]] = []
+    for metric in metrics:
+        values = _validated_hpo_metric_values(results, metric)
+        missing_budgets = {earlier_budget, later_budget} - set(values["budget"])
+        if missing_budgets:
+            raise ValueError(
+                "HPO budget changes omit budget(s) "
+                + ", ".join(str(value) for value in sorted(missing_budgets))
+            )
+        for problem_key, problem_rows in values.groupby("problem", sort=True):
+            problem = str(problem_key)
+            run_ids = sorted(int(value) for value in problem_rows["run_id"].unique())
+            context_seed = problem_context_seed(seed, problem)
+            draws = _bootstrap_draws(
+                run_ids,
+                context_seed=context_seed,
+                n_resamples=n_resamples,
+            )
+            for optimizer_key in sorted(problem_rows["optimizer"].unique()):
+                optimizer = str(optimizer_key)
+                later = problem_rows[
+                    problem_rows["optimizer"].eq(optimizer)
+                    & problem_rows["budget"].eq(later_budget)
+                ]
+                earlier = problem_rows[
+                    problem_rows["optimizer"].eq(optimizer)
+                    & problem_rows["budget"].eq(earlier_budget)
+                ]
+                paired = _paired_hpo_cells(
+                    later,
+                    earlier,
+                    require_shared_search_seed=False,
+                )
+                statistics = _paired_difference_statistics(
+                    paired,
+                    draws=draws,
+                    confidence_level=confidence_level,
+                )
+                rows.append(
+                    {
+                        "problem": problem,
+                        "metric": metric,
+                        "metric_direction": "higher_is_better",
+                        "contrast_type": "paired_budget_change",
+                        "optimizer": optimizer,
+                        "earlier_budget": earlier_budget,
+                        "later_budget": later_budget,
+                        "difference_definition": "later_budget - earlier_budget",
+                        "positive_difference_favors": "later_budget",
+                        "median_paired_difference": statistics["median_paired_difference"],
+                        "ci_lower": statistics["ci_lower"],
+                        "ci_upper": statistics["ci_upper"],
+                        "n_total_pairs": statistics["n_total_pairs"],
+                        "n_complete_pairs": statistics["n_complete_pairs"],
+                        "n_incomplete_pairs": statistics["n_incomplete_pairs"],
+                        "n_later_budget_failures": statistics["n_focal_failures"],
+                        "n_earlier_budget_failures": statistics["n_reference_failures"],
+                        "bootstrap_valid_resamples": statistics["bootstrap_valid_resamples"],
+                        "confidence_level": confidence_level,
+                        "bootstrap_resamples": n_resamples,
+                        "bootstrap_method": HPO_PAIRED_DIFFERENCE_BOOTSTRAP_METHOD,
+                        "bootstrap_seed": seed,
+                        "bootstrap_context_seed": context_seed,
+                    }
+                )
+    return pd.DataFrame(rows).sort_values(["metric", "optimizer"], ignore_index=True)
 
 
 def plot_hpo_metric(summary: pd.DataFrame, output_dir: Path, metric: str) -> None:
@@ -152,6 +460,32 @@ def main() -> None:
         index=False,
     )
     failures.to_csv(args.output_dir / "hpo_failures.csv", index=False)
+    mechanism_optimizers = {HPO_GMM_OPTIMIZER, *HPO_GMM_COMPARATORS}
+    if mechanism_optimizers.issubset(set(results["optimizer"])):
+        optimizer_contrasts = summarize_hpo_optimizer_contrasts(
+            results,
+            n_resamples=args.bootstrap_resamples,
+            seed=args.bootstrap_seed,
+        )
+        optimizer_contrasts.to_csv(
+            args.output_dir / "hpo_paired_optimizer_contrasts.csv",
+            index=False,
+        )
+    else:
+        missing = sorted(mechanism_optimizers - set(results["optimizer"]))
+        print("Skipped HOLA HPO GMM contrasts; campaign omits " + ", ".join(missing))
+    if set(HPO_BUDGET_CHANGE).issubset(set(int(value) for value in results["budget"])):
+        budget_changes = summarize_hpo_budget_changes(
+            results,
+            n_resamples=args.bootstrap_resamples,
+            seed=args.bootstrap_seed,
+        )
+        budget_changes.to_csv(
+            args.output_dir / "hpo_paired_budget_changes.csv",
+            index=False,
+        )
+    else:
+        print("Skipped HPO 25-to-100 budget contrasts; campaign omits budget 25 or 100")
     for metric in HPO_METRICS:
         plot_hpo_metric(summaries[metric], args.output_dir, metric)
 

--- a/hola-py/benchmarks/plotting/multi_objective.py
+++ b/hola-py/benchmarks/plotting/multi_objective.py
@@ -29,7 +29,12 @@ from benchmarks.data.composite import (
     SOURCE_RESULTS_COLUMN,
     load_reporting_results,
 )
-from benchmarks.data.normalize import lexicographic_failure_ranks
+from benchmarks.data.normalize import (
+    DEFAULT_BOOTSTRAP_SAMPLES,
+    DEFAULT_BOOTSTRAP_SEED,
+    aggregate_family_balanced_paired_win_rates,
+    lexicographic_failure_ranks,
+)
 from benchmarks.data.persistence import SOURCE_RESULT_ROW_INDEX_COLUMN
 from benchmarks.plotting.export import save_figure
 from benchmarks.plotting.style import apply_paper_style, get_color
@@ -41,6 +46,18 @@ PRIMARY_METRICS = {
     "normalized_hypervolume_gap": "Normalized hypervolume gap",
     "normalized_igd": "Normalized IGD",
 }
+GMM_OPTIMIZER = "HOLA MO (GMM)"
+GMM_MECHANISM_COMPARATORS = ("HOLA MO (random)", "HOLA MO (sobol)")
+GMM_PAIRED_WIN_METRICS = ("normalized_igd", "normalized_hypervolume_gap")
+GMM_PAIRED_WIN_AGGREGATION = (
+    "mean within each concrete task; equal task weight within named family; "
+    "equal named-family weight"
+)
+GMM_PAIRED_WIN_BOOTSTRAP_METHOD = (
+    "resample already-paired focal/comparator outcome scores independently within each "
+    "concrete task; "
+    "equal task/family weighting; percentile interval"
+)
 FAILURE_COLUMNS = [
     "problem",
     "optimizer",
@@ -579,6 +596,77 @@ def aggregate_family_balanced_metric_ranks(
     )
 
 
+def summarize_gmm_paired_win_rates(
+    results: pd.DataFrame,
+    *,
+    metrics: Sequence[str] = GMM_PAIRED_WIN_METRICS,
+    n_bootstrap: int = DEFAULT_BOOTSTRAP_SAMPLES,
+    seed: int = DEFAULT_BOOTSTRAP_SEED,
+) -> pd.DataFrame:
+    """Compare HOLA GMM with its exploration strategies on paired runs.
+
+    A win means that GMM has a lower fixed-scale metric than its comparator;
+    exact metric ties contribute one half. Concrete tasks receive equal weight
+    within their registered named family, and named families receive equal
+    weight in the reported rate.
+    """
+    required = {
+        "problem",
+        "optimizer",
+        "budget",
+        "run_id",
+        "status",
+        *metrics,
+    }
+    missing = required - set(results.columns)
+    if missing:
+        raise ValueError(f"missing MO paired-win columns: {', '.join(sorted(missing))}")
+    unknown = sorted(set(results["problem"].dropna()) - set(MULTI_OBJECTIVE_PROBLEMS))
+    if unknown:
+        raise ValueError(f"unknown multi-objective problems: {', '.join(unknown)}")
+    if not metrics:
+        raise ValueError("MO paired-win reporting requires at least one metric")
+    unknown_metrics = sorted(set(metrics) - set(PRIMARY_METRICS))
+    if unknown_metrics:
+        raise ValueError(f"unknown MO paired-win metrics: {', '.join(unknown_metrics)}")
+
+    family_by_problem = {
+        name: problem.family or name for name, problem in MULTI_OBJECTIVE_PROBLEMS.items()
+    }
+    dimensions_by_problem = {
+        name: problem.dimensionality for name, problem in MULTI_OBJECTIVE_PROBLEMS.items()
+    }
+    summaries: list[pd.DataFrame] = []
+    for metric in metrics:
+        comparison = results.assign(
+            suite="multi_objective",
+            family=results["problem"].map(family_by_problem),
+            dimension=results["problem"].map(dimensions_by_problem),
+            regret=pd.to_numeric(results[metric], errors="coerce"),
+        )
+        summary = aggregate_family_balanced_paired_win_rates(
+            comparison,
+            focal_optimizer=GMM_OPTIMIZER,
+            comparators=GMM_MECHANISM_COMPARATORS,
+            n_bootstrap=n_bootstrap,
+            seed=seed,
+        )
+        summary.insert(1, "metric", metric)
+        summary.insert(2, "metric_direction", "lower_is_better")
+        summary["win_definition"] = (
+            "focal metric < comparator metric; exact ties contribute 0.5; "
+            "a sole successful focal run wins and a sole successful comparator run loses"
+        )
+        summary["aggregation_method"] = GMM_PAIRED_WIN_AGGREGATION
+        summary["bootstrap_method"] = GMM_PAIRED_WIN_BOOTSTRAP_METHOD
+        summaries.append(summary)
+
+    return pd.concat(summaries, ignore_index=True).sort_values(
+        ["metric", "comparator", "budget"],
+        ignore_index=True,
+    )
+
+
 def plot_family_balanced_metric_ranks(
     ranks: pd.DataFrame,
     output_dir: Path,
@@ -742,6 +830,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Generate multi-objective plots")
     parser.add_argument("--results-dir", type=Path, default=Path("benchmark_results"))
     parser.add_argument("--output-dir", type=Path, default=Path("benchmark_results/plots"))
+    parser.add_argument(
+        "--bootstrap-resamples",
+        type=int,
+        default=DEFAULT_BOOTSTRAP_SAMPLES,
+    )
+    parser.add_argument("--bootstrap-seed", type=int, default=DEFAULT_BOOTSTRAP_SEED)
     args = parser.parse_args()
 
     df = load_reporting_results(args.results_dir, "multi_objective")
@@ -756,6 +850,20 @@ def main() -> None:
     for metric, label in PRIMARY_METRICS.items():
         plot_metric_by_budget(df, args.output_dir, metric, label)
     summary = write_metrics_table(df, args.output_dir)
+    mechanism_optimizers = {GMM_OPTIMIZER, *GMM_MECHANISM_COMPARATORS}
+    if mechanism_optimizers.issubset(set(df["optimizer"])):
+        paired_win_rates = summarize_gmm_paired_win_rates(
+            df,
+            n_bootstrap=args.bootstrap_resamples,
+            seed=args.bootstrap_seed,
+        )
+        paired_win_rates.to_csv(
+            args.output_dir / "multi_objective_gmm_paired_win_rates.csv",
+            index=False,
+        )
+    else:
+        missing = sorted(mechanism_optimizers - set(df["optimizer"]))
+        print("Skipped HOLA MO GMM mechanism comparison; campaign omits " + ", ".join(missing))
     summary_metrics = {
         "hv_gap_median": ("normalized_hypervolume_gap", "normalized hypervolume gap"),
         "igd_median": ("normalized_igd", "normalized IGD"),

--- a/hola-py/tests/test_benchmark_analysis.py
+++ b/hola-py/tests/test_benchmark_analysis.py
@@ -31,7 +31,10 @@ from benchmarks.metrics.spacing import (  # noqa: E402
     compute_spacing,
 )
 from benchmarks.plotting.multi_objective import (  # noqa: E402
+    GMM_MECHANISM_COMPARATORS,
+    GMM_OPTIMIZER,
     aggregate_family_balanced_metric_ranks,
+    summarize_gmm_paired_win_rates,
     summarize_multiobjective_metrics,
 )
 from benchmarks.problems.multi_objective import MULTI_OBJECTIVE_PROBLEMS  # noqa: E402
@@ -199,6 +202,47 @@ def test_multiobjective_family_balance_keeps_primary_metrics_separate() -> None:
     assert igd_ranks.loc["left", "mean_rank"] == pytest.approx(1.75)
     assert igd_ranks.loc["right", "mean_rank"] == pytest.approx(1.25)
     assert hv_ranks["n_families"].tolist() == [2, 2]
+
+
+@pytest.mark.benchmarks
+def test_multiobjective_gmm_paired_win_rate_balances_named_families() -> None:
+    rows = []
+    for problem in ("zdt1_30d", "dtlz1_3obj_7d", "dtlz1_5obj_9d"):
+        for run_id in range(2):
+            for optimizer in (GMM_OPTIMIZER, *GMM_MECHANISM_COMPARATORS):
+                gmm_wins = problem == "zdt1_30d"
+                metric = 0.0 if (optimizer == GMM_OPTIMIZER) == gmm_wins else 1.0
+                rows.append(
+                    {
+                        "problem": problem,
+                        "optimizer": optimizer,
+                        "budget": 200,
+                        "run_id": run_id,
+                        "status": "success",
+                        "normalized_hypervolume_gap": metric,
+                        "normalized_igd": metric,
+                    }
+                )
+
+    summary = summarize_gmm_paired_win_rates(
+        pd.DataFrame(rows),
+        n_bootstrap=128,
+        seed=123,
+    )
+
+    assert len(summary) == 4
+    assert summary["win_rate"].tolist() == pytest.approx([0.5] * 4)
+    assert set(summary["n_families"]) == {2}
+    assert set(summary["n_tasks"]) == {3}
+    assert set(summary["n_paired_runs"]) == {2}
+    assert set(summary["n_paired_outcomes"]) == {6}
+    assert set(summary["n_wins"]) == {2}
+    assert set(summary["n_losses"]) == {4}
+    assert set(summary["metric_direction"]) == {"lower_is_better"}
+    assert set(summary["aggregation_method"]) == {
+        "mean within each concrete task; equal task weight within named family; "
+        "equal named-family weight"
+    }
 
 
 @pytest.mark.benchmarks

--- a/hola-py/tests/test_multiobjective_representative_fronts.py
+++ b/hola-py/tests/test_multiobjective_representative_fronts.py
@@ -227,3 +227,60 @@ def test_plot_multi_writes_selected_row_and_metrics_to_audit_csv(
     assert audit.loc[0, "normalized_igd"] == pytest.approx(0.2)
     assert audit.loc[0, "spacing"] == pytest.approx(0.05)
     assert plotted == [(1, 2)]
+
+
+def test_plot_multi_writes_gmm_paired_win_rate_audit_csv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    values = {
+        multi_plotting.GMM_OPTIMIZER: (0.1, 0.2),
+        multi_plotting.GMM_MECHANISM_COMPARATORS[0]: (0.2, 0.3),
+        multi_plotting.GMM_MECHANISM_COMPARATORS[1]: (0.1, 0.4),
+    }
+    results = pd.DataFrame(
+        [
+            _result_row(
+                optimizer,
+                run_id,
+                gap,
+                problem="zdt1_30d",
+                igd=igd,
+            )
+            for optimizer, (gap, igd) in values.items()
+            for run_id in range(2)
+        ]
+    )
+    monkeypatch.setattr(multi_plotting, "load_reporting_results", lambda *_: results)
+    monkeypatch.setattr(multi_plotting, "plot_metric_by_budget", lambda *args: None)
+    monkeypatch.setattr(
+        multi_plotting,
+        "plot_family_balanced_metric_ranks",
+        lambda *args: None,
+    )
+    output_dir = tmp_path / "plots"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "plot-multi",
+            "--results-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(output_dir),
+            "--bootstrap-resamples",
+            "64",
+        ],
+    )
+
+    multi_plotting.main()
+
+    audit = pd.read_csv(output_dir / "multi_objective_gmm_paired_win_rates.csv")
+    assert len(audit) == 4
+    assert set(audit["metric"]) == {"normalized_hypervolume_gap", "normalized_igd"}
+    assert set(audit["comparator"]) == set(multi_plotting.GMM_MECHANISM_COMPARATORS)
+    assert set(audit["bootstrap_samples"]) == {64}
+    assert set(audit["win_definition"]) == {
+        "focal metric < comparator metric; exact ties contribute 0.5; "
+        "a sole successful focal run wins and a sole successful comparator run loses"
+    }

--- a/hola-py/tests/test_secondary_reporting.py
+++ b/hola-py/tests/test_secondary_reporting.py
@@ -113,8 +113,8 @@ def test_paired_bootstrap_records_an_all_failure_resample(
 
 
 def _hpo_manifest() -> dict[str, Any]:
-    optimizers = ["left", "right"]
-    budgets = [25, 50]
+    optimizers = [hpo_reporting.HPO_GMM_OPTIMIZER, *hpo_reporting.HPO_GMM_COMPARATORS]
+    budgets = list(hpo_reporting.HPO_BUDGET_CHANGE)
     return build_campaign_manifest(
         run_kind="hpo",
         budgets=budgets,
@@ -138,10 +138,13 @@ def _hpo_manifest() -> dict[str, Any]:
 def _write_hpo_campaign(path: Path) -> ResultStore:
     store = ResultStore(path)
     store.prepare_campaign(_hpo_manifest(), resume=False)
-    for optimizer_index, optimizer in enumerate(("left", "right")):
-        for budget in (25, 50):
+    optimizers = [hpo_reporting.HPO_GMM_OPTIMIZER, *hpo_reporting.HPO_GMM_COMPARATORS]
+    for optimizer_index, optimizer in enumerate(optimizers):
+        for budget in hpo_reporting.HPO_BUDGET_CHANGE:
             for run_id in range(3):
-                failed = optimizer == "right" and budget == 25 and run_id == 2
+                failed = optimizer == hpo_reporting.HPO_GMM_COMPARATORS[-1] and (
+                    budget == 25 and run_id == 2
+                )
                 store.append_hpo(
                     {
                         "problem": "gbr_diabetes_hpo",
@@ -155,12 +158,16 @@ def _write_hpo_campaign(path: Path) -> ResultStore:
                         "optimizer_config": {"adapter": optimizer},
                         "n_validation_evaluations": 10 if failed else budget,
                         "best_validation_r2": (
-                            None if failed else 0.4 + 0.01 * run_id + 0.02 * optimizer_index
+                            None
+                            if failed
+                            else 0.4 + 0.01 * run_id + 0.02 * optimizer_index + budget / 10_000
                         ),
                         "best_params": None if failed else {"n_estimators": 50},
                         "validation_trace": None if failed else [0.4] * budget,
                         "heldout_test_r2": (
-                            None if failed else 0.3 + 0.01 * run_id + 0.02 * optimizer_index
+                            None
+                            if failed
+                            else 0.3 + 0.01 * run_id + 0.02 * optimizer_index + budget / 20_000
                         ),
                         "n_heldout_evaluations": 0 if failed else 1,
                         "train_size": 264,
@@ -204,16 +211,72 @@ def test_hpo_cli_writes_separate_authenticated_audit_summaries(
     validation = pd.read_csv(output_dir / "hpo_validation_summary.csv")
     heldout = pd.read_csv(output_dir / "hpo_heldout_summary.csv")
     failures = pd.read_csv(output_dir / "hpo_failures.csv")
+    optimizer_contrasts = pd.read_csv(output_dir / "hpo_paired_optimizer_contrasts.csv")
+    budget_changes = pd.read_csv(output_dir / "hpo_paired_budget_changes.csv")
     assert set(validation["metric"]) == {"best_validation_r2"}
     assert set(heldout["metric"]) == {"heldout_test_r2"}
     assert set(validation["bootstrap_method"]) == {
         "paired run-id resampling; median; percentile interval"
     }
     assert failures[["optimizer", "budget", "run_id"]].to_records(index=False).tolist() == [
-        ("right", 25, 2)
+        (hpo_reporting.HPO_GMM_COMPARATORS[-1], 25, 2)
     ]
     assert failures.loc[0, "search_seed"] != failures.loc[0, "split_seed"]
+    assert len(optimizer_contrasts) == 12
+    assert set(optimizer_contrasts["difference_definition"]) == {
+        "focal_optimizer - reference_optimizer"
+    }
+    assert set(optimizer_contrasts["positive_difference_favors"]) == {"focal_optimizer"}
+    assert len(budget_changes) == 8
+    assert set(budget_changes["difference_definition"]) == {"later_budget - earlier_budget"}
+    assert set(budget_changes["positive_difference_favors"]) == {"later_budget"}
+    assert set(budget_changes["earlier_budget"]) == {25}
+    assert set(budget_changes["later_budget"]) == {100}
     assert plotted == ["best_validation_r2", "heldout_test_r2"]
+
+
+def test_hpo_paired_contrasts_are_deterministic_and_keep_outcomes_separate(
+    tmp_path: Path,
+) -> None:
+    results = _write_hpo_campaign(tmp_path / "hpo-contrasts").load_complete_hpo()
+    shuffled = results.sample(frac=1.0, random_state=17).reset_index(drop=True)
+
+    optimizer_contrasts = hpo_reporting.summarize_hpo_optimizer_contrasts(
+        results,
+        n_resamples=257,
+        seed=123,
+    )
+    shuffled_optimizer_contrasts = hpo_reporting.summarize_hpo_optimizer_contrasts(
+        shuffled,
+        n_resamples=257,
+        seed=123,
+    )
+    pd.testing.assert_frame_equal(optimizer_contrasts, shuffled_optimizer_contrasts)
+    random_at_100 = optimizer_contrasts[
+        optimizer_contrasts["reference_optimizer"].eq(hpo_reporting.HPO_GMM_COMPARATORS[0])
+        & optimizer_contrasts["budget"].eq(100)
+    ]
+    assert random_at_100["median_paired_difference"].tolist() == pytest.approx([-0.02, -0.02])
+    assert set(random_at_100["metric"]) == {"best_validation_r2", "heldout_test_r2"}
+    assert set(random_at_100["metric_direction"]) == {"higher_is_better"}
+
+    budget_changes = hpo_reporting.summarize_hpo_budget_changes(
+        shuffled,
+        n_resamples=257,
+        seed=123,
+    )
+    gmm_changes = budget_changes[
+        budget_changes["optimizer"].eq(hpo_reporting.HPO_GMM_OPTIMIZER)
+    ].set_index("metric")
+    assert gmm_changes.loc["best_validation_r2", "median_paired_difference"] == pytest.approx(
+        0.0075
+    )
+    assert gmm_changes.loc["heldout_test_r2", "median_paired_difference"] == pytest.approx(0.00375)
+    assert (gmm_changes["ci_lower"] <= gmm_changes["median_paired_difference"]).all()
+    assert (gmm_changes["ci_upper"] >= gmm_changes["median_paired_difference"]).all()
+    assert set(budget_changes["bootstrap_method"]) == {
+        "paired run-id resampling; median of paired differences; percentile interval"
+    }
 
 
 def test_hpo_cli_authenticates_completeness_before_writing(


### PR DESCRIPTION
Summary
- report family-balanced paired GMM win rates for both multi-objective primary metrics
- report paired HPO optimizer contrasts and 25-to-100 budget changes without mixing validation and held-out outcomes
- record pairing, bootstrap, failure, and aggregation metadata in the generated CSVs

Validation
- 30 focused pytest tests passed
- focused Ruff checks passed
- focused ty checks passed
- authenticated final-v6 composite smoke reproduced the audited contrast values